### PR TITLE
v3.4.0 and API changes

### DIFF
--- a/custom_components/ecotrend_ista/config_flow.py
+++ b/custom_components/ecotrend_ista/config_flow.py
@@ -30,7 +30,6 @@ def login_account(hass: core.HomeAssistant, data: MappingProxyType[str, Any], de
     account = PyEcotrendIsta(
         email=data.get(CONF_EMAIL, None),
         password=data.get(CONF_PASSWORD, None),
-        logger=_LOGGER,
         totp=data.get(CONF_MFA, "").replace(" ", ""),
         session=requests.Session(),
     )

--- a/custom_components/ecotrend_ista/coordinator.py
+++ b/custom_components/ecotrend_ista/coordinator.py
@@ -86,7 +86,7 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
             if self.data is None:
                 self.data = {}
             await self.init()
-            for uuid in self.controller.getUUIDs():
+            for uuid in self.controller.get_uuids():
                 _consum_raw: dict[str, Any] = await self.hass.async_add_executor_job(
                     self.controller.consum_raw,
                     [
@@ -104,7 +104,7 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
                 await create_directory_file(
                     self.hass,
                     consum_raw,
-                    self.controller.getSupportCode(),
+                    self.controller.get_support_code(),
                 )
                 self.data[uuid] = consum_raw
             self.async_set_updated_data(self.data)

--- a/custom_components/ecotrend_ista/entity.py
+++ b/custom_components/ecotrend_ista/entity.py
@@ -93,7 +93,7 @@ SENSOR_TYPES: tuple[EcotrendSensorEntityDescription, ...] = (
     EcotrendSensorEntityDescription(
         key=CONF_TYPE_HEATING,
         data_type=CONF_TYPE_HEATING,
-        device_class=SensorDeviceClass.ENERGY,
+        # device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:radiator",

--- a/custom_components/ecotrend_ista/manifest.json
+++ b/custom_components/ecotrend_ista/manifest.json
@@ -12,9 +12,9 @@
     "issue_tracker": "https://github.com/Ludy87/ecotrend-ista/issues",
     "loggers": ["pyecotrend_ista"],
     "requirements": [
-        "pyecotrend_ista==3.3.1",
+        "pyecotrend_ista==3.4.0",
         "pyotp==2.8.0",
         "marshmallow-enum==1.5.1"
     ],
-    "version": "v3.3.0"
+    "version": "v3.4.0"
 }

--- a/custom_components/ecotrend_ista/sensor.py
+++ b/custom_components/ecotrend_ista/sensor.py
@@ -44,16 +44,16 @@ class EcotrendBaseEntityV3(CoordinatorEntity[IstaDataUpdateCoordinator], Restore
         """Initialize the ista EcoTrend Version 3 base entity."""
         super().__init__(coordinator)
         self._attr_attribution = f"Data provided by {URL_SELECTORS.get(self.coordinator.config_entry.options.get(CONF_URL))}"
-        self._support_code = controller._support_code
+        self._support_code = controller.get_support_code()
         self.uuid = uuid
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{self.uuid}")},
             manufacturer=f"{MANUFACTURER} {self.uuid}",
             model="ista consumption & costs",
-            name=f"{DEVICE_NAME} {self.uuid} {'' if controller._access_token != 'Demo' else 'Demo'}",
+            name=f"{DEVICE_NAME} {self.uuid} {'' if controller.access_token != 'Demo' else 'Demo'}",
             sw_version=controller.get_version(),
-            hw_version=controller._account.get("tosUpdated"),
-            via_device=(DOMAIN, f"{self.uuid}"),
+            hw_version=(controller.get_account() or {}).get("tosUpdated"),
+            # via_device=(DOMAIN, f"{self.uuid}"),
         )
         self._unsub_dispatchers: list[Callable[[], None]] = []
 
@@ -136,7 +136,7 @@ async def async_setup_entry(
 
     controller = coordinator.controller
 
-    for uuid in controller.getUUIDs():
+    for uuid in controller.get_uuids():
         entities: list = []
         consum_raw: CustomRaw = CustomRaw.from_dict(
             await hass.async_add_executor_job(

--- a/hacs.json
+++ b/hacs.json
@@ -3,7 +3,7 @@
     "zip_release": true,
     "country": "DE",
     "render_readme": true,
-    "homeassistant": "2024.6.4",
-    "hacs": "1.34.0",
+    "homeassistant": "2025.10.1",
+    "hacs": "2.0.5",
     "filename": "ecotrend_ista.zip"
 }


### PR DESCRIPTION
Bump pyecotrend_ista to v3.4.0 and update Home Assistant and HACS requirements. Refactor code to use new controller API methods (get_uuids, get_support_code, get_account, access_token) and remove deprecated logger argument. Comment out device_class for heating sensor entity.