### PR TITLE
Fix invalid translation URLs in strings.json

### DIFF
--- a/custom_components/ecotrend_ista/strings.json
+++ b/custom_components/ecotrend_ista/strings.json
@@ -25,21 +25,6 @@
         },
         "description": "[%key:common::config_flow::german::description%]",
         "title": "[%key:common::config_flow::german::title%]"
-      },
-      "user": {
-        "data": {
-          "URL": "[%key:common::config_flow::data::URL%]",
-          "email": "[%key:common::config_flow::data::email%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        },
-        "description": "[%key:common::config_flow::german::description%]",
-        "menu_options": {
-          "denmark": "",
-          "francais": "https://ma-consommation.ista.lu/",
-          "german": "https://www.ecotrend.ista.de/",
-          "netherland": "https://mijn.ista.nl/"
-        },
-        "title": "[%key:common::config_flow::user::title%]"
       }
     }
   },


### PR DESCRIPTION
### Motivation
- Home Assistant translation validation failed because `custom_components/ecotrend_ista/strings.json` contained raw URLs in an unused `user` config step `menu_options`, so those entries needed to be removed.

### Description
- Remove the unused `user` config step block (including `menu_options` with URL values) from `custom_components/ecotrend_ista/strings.json` so translation strings no longer include raw URLs.

### Testing
- Validated the JSON with `python -m json.tool custom_components/ecotrend_ista/strings.json`, ran a URL scan script to ensure no `http(s)://` occurrences remain, and executed `pytest -q`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d6444cd48325b50fa6c916667898)