### PR TITLE
Add Dependabot group for github/codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       time: "22:30"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 5
+    groups:
+      github-codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
### Motivation
- Group Dependabot updates for the CodeQL GitHub Action so updates matching `github/codeql-action*` are consolidated into a single PR.

### Description
- Added a `groups` entry to `.github/dependabot.yml` with a `github-codeql-action` group that matches the pattern `github/codeql-action*`.

### Testing
- Ran `ruby -e 'require "yaml"; data=YAML.load_file(".github/dependabot.yml"); raise unless data["updates"][0]["groups"]["github-codeql-action"]["patterns"] == ["github/codeql-action*"]; puts "dependabot.yml parsed successfully"'` which succeeded.
- Ran `git diff --check` which reported no issues.
- Attempted a `python` YAML parse (`python - <<'PY' ...`) which failed due to the environment missing the `yaml` module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ef2a37e48325b6bcb27f78ac06f5)