### PR TITLE
Add Czech ista EcoTrend portal support

### DIFF
--- a/CZECH_PORTAL_CS.md
+++ b/CZECH_PORTAL_CS.md
@@ -1,0 +1,50 @@
+# Podpora českého portálu ista EcoTrend
+
+Integrace podporuje české účty dostupné přes portál `https://ecotrend.ista.cz/`. Data získává přímo z backendu používaného zákaznickou aplikací ista EcoTrend; nepoužívá scraping webové stránky ani automatizovaný prohlížeč.
+
+Jde o neoficiální komunitní implementaci, která není spojena se společností ista ani jí podporována. Backend se může bez předchozího upozornění změnit nebo omezit přístup. Integraci používejte pouze s účtem a údaji, ke kterým máte oprávněný přístup.
+
+## Nastavení
+
+1. Nainstalujte integraci přes HACS a restartujte Home Assistant.
+2. V Home Assistantu otevřete **Nastavení → Zařízení a služby → Přidat integraci**.
+3. Vyhledejte **ista EcoTrend**.
+4. Jako přihlašovací URL vyberte `https://ecotrend.ista.cz/`.
+5. Zadejte uživatelské jméno a heslo českého účtu ista.
+6. Doporučený interval aktualizace je 24 hodin.
+
+Český backend aktuálně nevyužívá kód dvoufázového ověření. Kratší interval, například jedna hodina, je vhodný pouze pro dočasné ověření synchronizace.
+
+## Dostupná data
+
+Integrace vytváří:
+
+- samostatný senzor posledního dostupného kumulativního stavu každého fyzického měřidla,
+- poslední dostupnou denní spotřebu vytápění, teplé vody a studené vody,
+- spotřebu za poslední dostupný měsíc,
+- senzor **Data dostupná do**, který ukazuje poslední datum zveřejněné společností ista,
+- dlouhodobé statistiky denní spotřeby pro vytápění, teplou vodu a studenou vodu.
+
+Počet fyzických měřidel závisí na konkrétním bytě a účtu. Historická data poskytuje API souhrnně podle typu spotřeby, nikoli samostatně pro každý radiátor nebo vodoměr.
+
+## Historie a zpoždění
+
+ista může hodnoty zveřejňovat s několikadenním zpožděním. Integrace zachovává skutečné datum měření a opožděnou hodnotu nevydává za dnešní spotřebu.
+
+Při aktualizaci se načítá denní historie za posledních 12 měsíců. Hodnoty se ukládají do dlouhodobých statistik Home Assistantu a lze je seskupovat po dnech nebo měsících. Měsíční senzor samotný ukazuje pouze poslední dostupný měsíc; starší měsíce jsou dostupné prostřednictvím dlouhodobých statistik, nikoli jako zpětně vytvořené stavy entity.
+
+Pokud ista později opraví starší denní hodnotu, integrace aktualizuje daný den a přepočítá navazující kumulativní statistické body.
+
+## Jednotky
+
+- Teplá a studená voda se vykazuje v m³.
+- Indikátory topných nákladů se vykazují v alokačních jednotkách, nikoli v kWh.
+- Fyzická měřidla zobrazují kumulativní stav. Denní a měsíční senzory zobrazují spotřebu za dané období.
+
+## Známá omezení
+
+- Externí dlouhodobé statistiky vyžadují aktivní komponentu Recorder.
+- Integrace aktualizuje data v nastaveném intervalu, nikoli v konkrétní denní hodinu.
+- Nově přidané nebo vyměněné měřidlo se vystaví po opětovném načtení integrace.
+- Při změně přihlašovacích údajů je zatím potřeba účet v integraci znovu nakonfigurovat; samostatný reautentizační postup není implementován.
+- Dostupný rozsah historie určuje backend ista. Integrace aktuálně požaduje posledních 12 měsíců.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ ista EcoTrend should now appear as a card under the HA Integrations page with "C
 
 ---
 
+## Supported portals and Czech data
+
+The integration supports the German portal at `ecotrend.ista.de` and the Czech portal at `ecotrend.ista.cz`. Select the matching portal during setup; Czech accounts can use the ista username shown for the account.
+
+Existing German portal accounts continue to use the original German API client, data parser, and sensor creation path. Czech-specific API handling is activated only for entries configured with the Czech portal (`cz_url`).
+
+For setup instructions and details in Czech, see [Podpora českého portálu ista EcoTrend](CZECH_PORTAL_CS.md).
+
+Czech portal support is an unofficial community implementation. It is not affiliated with or endorsed by ista and relies on the backend used by the ista EcoTrend customer application, which may change or restrict access without notice. Use it only with an account and data you are authorized to access.
+
+For Czech accounts, the integration provides cumulative physical meter readings, the latest available daily and monthly consumption, and a **Data available through** sensor. ista may publish Czech readings several days late. The integration keeps the actual measurement dates and does not present delayed data as today's consumption.
+
+Because Czech readings are delayed and historical data is fetched during updates, the default 24-hour update interval is recommended.
+
+Daily Czech history is backfilled into Home Assistant external statistics. If ista later corrects an older reading, the integration updates that day and recalculates the following cumulative statistic points.
+
+Water consumption is reported in m³. Heating allocator readings are reported in allocation units, not kWh. Physical meter entities show a cumulative reading, while daily and monthly entities show consumption for the corresponding period.
+
+---
+
 ## Two-factor authentication (experimental)
 
 - [Two-factor authentication deutsch](TWO_FACTOR_AUTHENTICATION_DE.md)

--- a/custom_components/ecotrend_ista/config_flow.py
+++ b/custom_components/ecotrend_ista/config_flow.py
@@ -2,32 +2,34 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import copy
 import logging
-from types import MappingProxyType
 from typing import Any
-
-from pyecotrend_ista.exception_classes import LoginError
-from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
-import requests
-import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import NumberSelector, NumberSelectorConfig, NumberSelectorMode
+from pyecotrend_ista.exception_classes import LoginError
+from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
+import requests
+import voluptuous as vol
 
 from .const import CONF_MFA, CONF_UPDATE_INTERVAL, CONF_URL, DOMAIN, MANUFACTURER
-from .const_schema import DATA_SCHEMA_EMAIL, URL_SELECTOR
+from .const_schema import DATA_SCHEMA_EMAIL, URL_SELECTOR, URL_SELECTORS
+from .czech_client import CzechPyEcotrendIsta
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @staticmethod
 @core.callback
-def login_account(hass: core.HomeAssistant, data: MappingProxyType[str, Any], demo: bool = False) -> PyEcotrendIsta:
+def login_account(hass: core.HomeAssistant, data: Mapping[str, Any], demo: bool = False) -> PyEcotrendIsta:
     """Log into an Ecotrend-Ista account and return an account instance."""
-    account = PyEcotrendIsta(
+    del hass, demo
+    account_class = CzechPyEcotrendIsta if data.get(CONF_URL) == "cz_url" else PyEcotrendIsta
+    account = account_class(
         email=data.get(CONF_EMAIL, None),
         password=data.get(CONF_PASSWORD, None),
         totp=data.get(CONF_MFA, "").replace(" ", ""),
@@ -40,14 +42,17 @@ async def validate_input(hass: core.HomeAssistant, data: dict[str, Any]) -> dict
     """Validate the user input allows us to connect.
     Data has the keys from DATA_SCHEMA_EMAIL with values provided by the user.
     """  # noqa: D205
-    if CONF_URL not in data or data[CONF_URL] != "de_url":
+    if CONF_URL not in data or data[CONF_URL] not in URL_SELECTORS:
         raise NotSupportedURL()
 
-    # pylint: disable=no-value-for-parameter
-    try:
-        vol.Email()(data.get(CONF_EMAIL))
-    except vol.Invalid as error:
-        raise vol.Invalid(error) from error
+    if data[CONF_URL] == "de_url":
+        # pylint: disable=no-value-for-parameter
+        try:
+            vol.Email()(data.get(CONF_EMAIL))
+        except vol.Invalid as error:
+            raise vol.Invalid(error) from error
+    elif not str(data.get(CONF_EMAIL, "")).strip():
+        raise vol.Invalid("Username is required")
 
     account = login_account(hass, data)
 
@@ -161,7 +166,7 @@ def validate_options_input(user_input: dict[str, Any]) -> dict[str, str]:
     """Validate the user input allows us to connect. Data has the keys from DATA_SCHEMA with values provided by the user."""
 
     errors = {}
-    if CONF_URL not in user_input or user_input[CONF_URL] != "de_url":
+    if CONF_URL not in user_input or user_input[CONF_URL] not in URL_SELECTORS:
         errors["base"] = "not_allowed"
     return errors
 

--- a/custom_components/ecotrend_ista/config_flow.py
+++ b/custom_components/ecotrend_ista/config_flow.py
@@ -17,7 +17,7 @@ import requests
 import voluptuous as vol
 
 from .const import CONF_MFA, CONF_UPDATE_INTERVAL, CONF_URL, DOMAIN, MANUFACTURER
-from .const_schema import DATA_SCHEMA_EMAIL, URL_SELECTOR, URL_SELECTORS
+from .const_schema import DATA_SCHEMA_EMAIL, URL_SELECTORS
 from .czech_client import CzechPyEcotrendIsta
 
 _LOGGER = logging.getLogger(__name__)
@@ -178,9 +178,9 @@ class IstaOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         """Handle options flow."""
         options = self.options
         errors: dict[str, str] = {}
+        current_url = options.get(CONF_URL, "de_url")
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_URL, default=options.get(CONF_URL, "de_url")): URL_SELECTOR,
                 vol.Required(CONF_UPDATE_INTERVAL, default=options.get(CONF_UPDATE_INTERVAL, 24)): NumberSelector(
                     NumberSelectorConfig(mode=NumberSelectorMode.SLIDER, min=1, max=24)
                 ),
@@ -188,9 +188,10 @@ class IstaOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
             }
         )
         if user_input is not None:
-            errors = validate_options_input(user_input)
+            updated_options = {CONF_URL: current_url, **user_input}
+            errors = validate_options_input(updated_options)
 
             if not errors:
-                return self.async_create_entry(title="", data=user_input)
+                return self.async_create_entry(title="", data=updated_options)
 
         return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors, last_step=True)

--- a/custom_components/ecotrend_ista/const_schema.py
+++ b/custom_components/ecotrend_ista/const_schema.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_SCAN_INTERVAL
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -17,6 +15,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+import voluptuous as vol
 
 from .const import (
     CONF_MFA,
@@ -31,6 +30,7 @@ from .const import (
 
 URL_SELECTORS = {
     "de_url": "https://ecotrend.ista.de/",
+    "cz_url": "https://ecotrend.ista.cz/",
     # "nl_url": "https://mijn.ista.nl/",
     # "fr_url": "https://ma-consommation.ista.lu/",
 }
@@ -44,7 +44,7 @@ URL_SELECTOR: SelectSelector = SelectSelector(
 )
 
 DATA_SCHEMA_EMAIL = {
-    vol.Required(CONF_EMAIL): TextSelector(TextSelectorConfig(type=TextSelectorType.EMAIL, multiline=False)),
+    vol.Required(CONF_EMAIL): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT, multiline=False)),
     vol.Required(CONF_PASSWORD): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD, multiline=False)),
     vol.Required(CONF_URL, default="de_url"): URL_SELECTOR,
     vol.Optional(CONF_MFA, default=""): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT, multiline=False)),

--- a/custom_components/ecotrend_ista/coordinator.py
+++ b/custom_components/ecotrend_ista/coordinator.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pyecotrend_ista.helper_object_de import CustomRaw
 from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
 import requests
@@ -98,9 +98,7 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
                 await self.init()
 
             if is_czech:
-                self.czech_data = await self.hass.async_add_executor_job(
-                    self.controller.get_home_assistant_data
-                )
+                self.czech_data = await self.hass.async_add_executor_job(self.controller.get_home_assistant_data)
                 await async_sync_czech_statistics(
                     self.hass,
                     self.controller.get_support_code(),
@@ -131,5 +129,5 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
                 self.data[uuid] = consum_raw
             self.async_set_updated_data(self.data)
             return self.data
-        except requests.Timeout:
-            pass
+        except requests.Timeout as error:
+            raise UpdateFailed("Timeout while communicating with ista EcoTrend") from error

--- a/custom_components/ecotrend_ista/coordinator.py
+++ b/custom_components/ecotrend_ista/coordinator.py
@@ -9,16 +9,16 @@ import logging
 import os
 from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from pyecotrend_ista.helper_object_de import CustomRaw
 from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
 import requests
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-
 from .config_flow import login_account
-from .const import CONF_UPDATE_INTERVAL, DOMAIN
+from .const import CONF_UPDATE_INTERVAL, CONF_URL, DOMAIN
+from .czech_statistics import async_sync_czech_statistics
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +54,7 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize ista EcoTrend Version 3 data updater."""
         self._entry = entry
+        self.czech_data: dict[str, Any] | None = None
         super().__init__(
             hass=hass,
             logger=_LOGGER,
@@ -68,7 +69,8 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
         This method initializes the PyEcotrendIsta controller instance with the provided email, password,
         and other necessary configurations.
         """
-        data = self._entry.data
+        data = dict(self._entry.data)
+        data[CONF_URL] = self._entry.options.get(CONF_URL, "de_url")
         self.controller = login_account(
             self.hass,
             data,
@@ -85,7 +87,27 @@ class IstaDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             if self.data is None:
                 self.data = {}
-            await self.init()
+            is_czech = self._entry.options.get(CONF_URL, "de_url") == "cz_url"
+            reuse_initial_login = (
+                is_czech
+                and self.czech_data is None
+                and hasattr(self, "controller")
+                and self.controller.access_token is not None
+            )
+            if not reuse_initial_login:
+                await self.init()
+
+            if is_czech:
+                self.czech_data = await self.hass.async_add_executor_job(
+                    self.controller.get_home_assistant_data
+                )
+                await async_sync_czech_statistics(
+                    self.hass,
+                    self.controller.get_support_code(),
+                    self.czech_data.get("aggregates", {}),
+                )
+                return self.czech_data
+
             for uuid in self.controller.get_uuids():
                 _consum_raw: dict[str, Any] = await self.hass.async_add_executor_job(
                     self.controller.consum_raw,

--- a/custom_components/ecotrend_ista/czech_client.py
+++ b/custom_components/ecotrend_ista/czech_client.py
@@ -1,0 +1,629 @@
+"""Client adapter for the Czech/Nordic ista EcoTrend service."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import copy
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+import hashlib
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+from cryptography.hazmat.primitives import hashes, padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from pyecotrend_ista.exception_classes import LoginError
+from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+CZECH_API_BASE_URL = "https://prod.istaonlinebeta.dk/"
+CZECH_TOKEN_URL = f"{CZECH_API_BASE_URL}token"
+CZECH_METERS_URL = f"{CZECH_API_BASE_URL}api/Meters"
+CZECH_READING_URL = f"{CZECH_API_BASE_URL}api/GetReadingData"
+CZECH_APP_VERSION = "3.2.1"
+
+_REQUEST_TIMEOUT = 30
+_PERIOD_MONTHLY_HISTORY = 2
+_PERIOD_DAILY_HISTORY = 4
+_DOTNET_DATE = re.compile(r"^/Date\((?P<milliseconds>-?\d+)")
+_LOGIN_KDF_PASSWORD = "P@%5w0r]>3mll04##22"
+_LOGIN_KDF_SALT = "(&(HBB%J&Y*B1-3mll04##22"
+_CUBIC_METRE_UNITS = {"cbm", "cubicmeter", "cubicmetre", "m3", "m³"}
+
+
+def _value_case_insensitive(data: dict[str, Any], key: str, default: Any = None) -> Any:
+    """Return a dictionary value without relying on server-side key casing."""
+    wanted = key.casefold()
+    for current_key, value in data.items():
+        if current_key.casefold() == wanted:
+            return value
+    return default
+
+
+def _unwrap_value(payload: Any, key: str) -> Any:
+    """Unwrap the ``Type<T>.Value`` structure used by the Nordic API."""
+    if not isinstance(payload, dict):
+        return payload
+
+    value = _value_case_insensitive(payload, key, payload)
+    if isinstance(value, dict):
+        for wrapper_key in ("Value", "_value"):
+            unwrapped = _value_case_insensitive(value, wrapper_key)
+            if unwrapped is not None:
+                return unwrapped
+    return value
+
+
+def _add_months(value: date, months: int) -> date:
+    """Add whole months while keeping the date valid."""
+    month_index = value.year * 12 + value.month - 1 + months
+    year, month_index = divmod(month_index, 12)
+    month = month_index + 1
+    month_lengths = (
+        31,
+        29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    )
+    return date(year, month, min(value.day, month_lengths[month - 1]))
+
+
+def _dotnet_timestamp(value: datetime) -> str:
+    """Match the invariant-style ``DateTime.Now.ToString()`` used by the WebGL build."""
+    hour = value.hour % 12 or 12
+    suffix = "AM" if value.hour < 12 else "PM"
+    return f"{value.month}/{value.day}/{value.year} {hour}:{value.minute:02}:{value.second:02} {suffix}"
+
+
+def _login_proofs(username: str, password: str, now: datetime | None = None) -> tuple[str, str]:
+    """Build the two encrypted form values required by the current Czech login endpoint."""
+    key_material = PBKDF2HMAC(
+        algorithm=hashes.SHA1(),
+        length=96,
+        salt=_LOGIN_KDF_SALT.encode("ascii"),
+        iterations=1000,
+    ).derive(_LOGIN_KDF_PASSWORD.encode("ascii"))
+
+    # The Unity client first consumes one Rijndael key/IV pair, then uses the
+    # second pair for AesCryptoServiceProvider and the transmitted values.
+    key = key_material[48:80]
+    initialization_vector = key_material[80:96]
+    timestamp = _dotnet_timestamp(now or datetime.now())
+
+    def encrypt(value: str) -> str:
+        padder = padding.PKCS7(128).padder()
+        padded = padder.update(f"{value}_{timestamp}".encode()) + padder.finalize()
+        encryptor = Cipher(algorithms.AES(key), modes.CBC(initialization_vector)).encryptor()
+        encrypted = encryptor.update(padded) + encryptor.finalize()
+        return "".join(f"_{byte}" for byte in encrypted)
+
+    return encrypt(username), encrypt(password)
+
+
+def _parse_reading_date(value: Any) -> datetime | None:
+    """Parse date formats emitted by the ASP.NET/Unity API."""
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    raw = value.strip()
+    dotnet_match = _DOTNET_DATE.match(raw)
+    if dotnet_match:
+        return datetime.fromtimestamp(int(dotnet_match.group("milliseconds")) / 1000, tz=UTC)
+
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+
+    for date_format in ("%d-%m-%Y", "%d.%m.%Y", "%Y-%m-%d", "%m-%Y", "%m/%Y"):
+        try:
+            return datetime.strptime(raw, date_format)
+        except ValueError:
+            continue
+    return None
+
+
+def _as_decimal(value: Any) -> Decimal | None:
+    """Convert API numbers, including comma-decimal strings, to Decimal."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip().replace("\u00a0", "").replace(" ", "")
+    if not normalized:
+        return None
+    if "," in normalized and "." in normalized:
+        normalized = normalized.replace(".", "").replace(",", ".")
+    else:
+        normalized = normalized.replace(",", ".")
+    try:
+        return Decimal(normalized)
+    except InvalidOperation:
+        return None
+
+
+def _decimal_string(value: Decimal) -> str:
+    """Return a representation compatible with the existing German parser."""
+    result = format(value, "f")
+    if "." in result:
+        result = result.rstrip("0").rstrip(".")
+    return result or "0"
+
+
+def _identifier_string(value: Any) -> str:
+    """Return stable text for string and numeric meter identifiers."""
+    if isinstance(value, str):
+        return value.strip()
+    decimal_value = _as_decimal(value)
+    if decimal_value is not None:
+        return _decimal_string(decimal_value)
+    return str(value)
+
+
+def _normalize_unit(value: Any, sensor_type: str) -> str:
+    """Normalize water volume aliases to the Home Assistant cubic-metre unit."""
+    unit = str(value or "").strip()
+    compact = re.sub(r"[\s._-]+", "", unit.casefold())
+    if sensor_type in {"warmwater", "water"} and compact in _CUBIC_METRE_UNITS:
+        return "m³"
+    return unit
+
+
+def _classify_meter(meter: dict[str, Any], meter_type: str) -> str | None:
+    """Map Nordic meter labels to the three sensor types supported by this integration."""
+    labels = [
+        meter_type,
+        str(_value_case_insensitive(meter, "METTYPE_CODE", "")),
+        str(_value_case_insensitive(meter, "METCAT_LABEL", "")),
+        str(_value_case_insensitive(meter, "Headline", "")),
+    ]
+    normalized = " ".join(labels).casefold()
+    compact_type = re.sub(r"[^a-z0-9]", "", meter_type.casefold())
+
+    if compact_type in {"hw", "hotwater", "warmwater"} or (
+        ("tepl" in normalized or "hot water" in normalized) and "vod" in normalized
+    ):
+        return "warmwater"
+    if compact_type in {"cw", "coldwater", "water"} or "studen" in normalized or "cold water" in normalized:
+        return "water"
+    if compact_type in {"heat", "heating", "hca", "energy"} or any(
+        label in normalized for label in ("teplo", "topen", "heat", "radiator")
+    ):
+        return "heating"
+    return None
+
+
+class CzechPyEcotrendIsta(PyEcotrendIsta):
+    """Expose the Czech/Nordic service through the interface used by the integration."""
+
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        totp: str | None = None,
+        session: requests.Session | None = None,
+    ) -> None:
+        """Initialize the Czech client; TOTP is currently not used by this service."""
+        del totp
+        self._email = email.strip()
+        self._password = password
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/json",
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+                ),
+            }
+        )
+        self._access_token: str | None = None
+        self._account: dict[str, Any] = {}
+        self._meters: list[dict[str, Any]] = []
+        self._consumption_cache: dict[str, Any] | None = None
+        self._uuid = ""
+        self._support_code = ""
+
+    @property
+    def access_token(self) -> str | None:
+        """Return the current bearer token."""
+        return self._access_token
+
+    def login(self, **kwargs: Any) -> None:
+        """Authenticate and load the meters available to the Czech account."""
+        del kwargs
+        self._consumption_cache = None
+        value1, value2 = _login_proofs(self._email, self._password)
+        response = self.session.post(
+            CZECH_TOKEN_URL,
+            data={
+                "grant_type": "password",
+                "username": self._email,
+                "password": self._password,
+                "value1": value1,
+                "value2": value2,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        if response.status_code in (400, 401):
+            try:
+                error = response.json().get("error_description", "Invalid username or password")
+            except (ValueError, AttributeError):
+                error = "Invalid username or password"
+            raise LoginError(error)
+        response.raise_for_status()
+
+        token_data = response.json()
+        access_token = _value_case_insensitive(token_data, "access_token")
+        if not access_token:
+            raise LoginError("The Czech ista service did not return an access token")
+        self._access_token = str(access_token)
+
+        instance_id = _value_case_insensitive(token_data, "InstanceId")
+        if instance_id in (None, "", 0, "0"):
+            instance_id = hashlib.sha256(self._email.encode()).hexdigest()[:12]
+        self._uuid = f"cz-{instance_id}"
+        self._support_code = self._uuid
+        self._account = {
+            "firstName": _value_case_insensitive(token_data, "FirstName", ""),
+            "email": _value_case_insensitive(token_data, "Email", self._email),
+            "country": "CZ",
+            "locale": _value_case_insensitive(token_data, "Language", "cz"),
+            "tosUpdated": None,
+            "supportCode": self._support_code,
+            "consumptionUnitUuids": [self._uuid],
+            "residentAndConsumptionUuidsMap": {self._uuid: self._uuid},
+        }
+        self._meters = self._get_meters()
+
+    def logout(self) -> None:
+        """Discard the local token; the Nordic service exposes no logout call."""
+        self._access_token = None
+
+    def get_uuids(self) -> list[str]:
+        """Return one account-scoped consumption unit."""
+        return [self._uuid] if self._uuid else []
+
+    def get_support_code(self) -> str:
+        """Return a stable identifier for filenames and the device title."""
+        return self._support_code
+
+    def get_version(self) -> str:
+        """Return the Czech web application version used to derive this adapter."""
+        return f"CZ Nordic {CZECH_APP_VERSION}"
+
+    def get_account(self) -> dict[str, Any]:
+        """Return normalized account metadata expected by the entity code."""
+        return self._account
+
+    def _authorization_headers(self) -> dict[str, str]:
+        if not self._access_token:
+            raise LoginError("The Czech ista account is not authenticated")
+        return {"Authorization": f"bearer {self._access_token}"}
+
+    def _get_meters(self) -> list[dict[str, Any]]:
+        response = self.session.get(
+            CZECH_METERS_URL,
+            headers=self._authorization_headers(),
+            timeout=_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        meters = _unwrap_value(response.json(), "Meters")
+        if meters is None:
+            return []
+        if isinstance(meters, dict):
+            meters = _value_case_insensitive(meters, "meters", [])
+        if not isinstance(meters, list):
+            _LOGGER.warning("Unexpected Czech ista meter response: %s", type(meters).__name__)
+            return []
+        return [meter for meter in meters if isinstance(meter, dict)]
+
+    def _get_readings(
+        self,
+        meter_type: str,
+        start: date,
+        end: date,
+        period: int = _PERIOD_MONTHLY_HISTORY,
+    ) -> dict[str, Any] | None:
+        url = (
+            f"{CZECH_READING_URL}/{start:%d-%m-%Y}/{end:%d-%m-%Y}/"
+            f"{period}/{quote(meter_type, safe='')}"
+        )
+        response = self.session.get(
+            url,
+            headers=self._authorization_headers(),
+            timeout=_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        readings = _unwrap_value(response.json(), "readingsList")
+        return readings if isinstance(readings, dict) else None
+
+    def get_home_assistant_data(self) -> dict[str, Any]:
+        """Return physical meters and daily/monthly aggregate histories for Home Assistant."""
+        if not self._meters:
+            self._meters = self._get_meters()
+
+        normalized_meters: list[dict[str, Any]] = []
+        meter_types: dict[str, tuple[str, dict[str, Any]]] = {}
+        for index, meter in enumerate(self._meters, start=1):
+            meter_type = str(_value_case_insensitive(meter, "MeterType", "")).strip().lower()
+            sensor_type = _classify_meter(meter, meter_type)
+            if not meter_type or not sensor_type:
+                continue
+            meter_types.setdefault(meter_type.casefold(), (sensor_type, meter))
+
+            meter_id = _value_case_insensitive(meter, "METER_ID")
+            if not meter_id:
+                meter_number = _value_case_insensitive(meter, "METER_NO")
+                installation_number = _value_case_insensitive(meter, "INST_NO")
+                fallback_parts = [
+                    _identifier_string(part)
+                    for part in (meter_number, installation_number)
+                    if part not in (None, "")
+                ]
+                meter_id = "-".join(fallback_parts) or f"{meter_type}-{index}"
+            reading_date = _parse_reading_date(_value_case_insensitive(meter, "Reading_date"))
+            last_reading = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Reading"))
+            last_consumption = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Consumption"))
+            unit = _normalize_unit(_value_case_insensitive(meter, "Unit", ""), sensor_type)
+            normalized_meters.append(
+                {
+                    "id": _identifier_string(meter_id),
+                    "type": sensor_type,
+                    "meter_type": meter_type,
+                    "meter_number": str(_value_case_insensitive(meter, "METER_NO", "") or ""),
+                    "installation_number": _identifier_string(
+                        _value_case_insensitive(meter, "INST_NO", "") or ""
+                    ),
+                    "room": str(_value_case_insensitive(meter, "ROOM_DESCR", "") or ""),
+                    "label": str(
+                        _value_case_insensitive(
+                            meter,
+                            "Headline",
+                            _value_case_insensitive(meter, "MeterText", ""),
+                        )
+                        or ""
+                    ),
+                    "category": str(_value_case_insensitive(meter, "METCAT_LABEL", "") or ""),
+                    "unit": unit,
+                    "value": _decimal_string(last_reading) if last_reading is not None else None,
+                    "last_consumption": (
+                        _decimal_string(last_consumption) if last_consumption is not None else None
+                    ),
+                    "reading_date": reading_date.isoformat() if reading_date is not None else None,
+                    "activation_date": _value_case_insensitive(meter, "Activation_date"),
+                    "deactivation_date": _value_case_insensitive(meter, "Deactivation_date"),
+                }
+            )
+
+        today = date.today()
+        start = _add_months(today, -12)
+        grouped_daily: dict[str, dict[date, dict[str, Any]]] = defaultdict(dict)
+
+        for meter_type, (sensor_type, meter) in meter_types.items():
+            readings_list = self._get_readings(meter_type, start, today, _PERIOD_DAILY_HISTORY)
+            if not readings_list:
+                continue
+            unit = _normalize_unit(
+                _value_case_insensitive(
+                    readings_list,
+                    "Unit",
+                    _value_case_insensitive(meter, "Unit", ""),
+                ),
+                sensor_type,
+            )
+            readings = _value_case_insensitive(readings_list, "Readings", [])
+            if not isinstance(readings, list):
+                continue
+
+            for reading in readings:
+                if not isinstance(reading, dict):
+                    continue
+                reading_date = _parse_reading_date(_value_case_insensitive(reading, "Date"))
+                value = _as_decimal(_value_case_insensitive(reading, "Value"))
+                cumulative_value = _as_decimal(_value_case_insensitive(reading, "AkkumulativValue"))
+                if reading_date is None or value is None:
+                    continue
+
+                day = reading_date.date()
+                current = grouped_daily[sensor_type].get(day)
+                if current is None:
+                    grouped_daily[sensor_type][day] = {
+                        "value": value,
+                        "cumulative_value": cumulative_value,
+                        "unit": unit,
+                    }
+                elif current["unit"] == unit:
+                    current["value"] += value
+                    if cumulative_value is not None:
+                        current["cumulative_value"] = (
+                            (current["cumulative_value"] or Decimal("0")) + cumulative_value
+                        )
+                else:
+                    _LOGGER.debug(
+                        "Skipping Czech ista %s daily value with incompatible units %s/%s",
+                        sensor_type,
+                        current["unit"],
+                        unit,
+                    )
+
+        aggregates: dict[str, dict[str, Any]] = {}
+        monthly_consumptions: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
+        for sensor_type, values_by_day in grouped_daily.items():
+            daily: list[dict[str, Any]] = []
+            monthly_values: dict[tuple[int, int], Decimal] = defaultdict(Decimal)
+            unit = ""
+            for day, values in sorted(values_by_day.items()):
+                unit = str(values["unit"])
+                value = values["value"]
+                cumulative_value = values["cumulative_value"]
+                daily.append(
+                    {
+                        "date": day.isoformat(),
+                        "value": _decimal_string(value),
+                        "cumulative_value": (
+                            _decimal_string(cumulative_value) if cumulative_value is not None else None
+                        ),
+                    }
+                )
+                monthly_values[(day.year, day.month)] += value
+
+            monthly = [
+                {
+                    "year": year,
+                    "month": month,
+                    "value": _decimal_string(value),
+                }
+                for (year, month), value in sorted(monthly_values.items())
+            ]
+            for (year, month), value in monthly_values.items():
+                monthly_consumptions[(year, month)][sensor_type] = (value, unit)
+
+            aggregates[sensor_type] = {
+                "unit": unit,
+                "daily": daily,
+                "monthly": monthly,
+                "daily_value": daily[-1]["value"] if daily else None,
+                "daily_date": daily[-1]["date"] if daily else None,
+                "monthly_value": monthly[-1]["value"] if monthly else None,
+                "monthly_year": monthly[-1]["year"] if monthly else None,
+                "monthly_month": monthly[-1]["month"] if monthly else None,
+                "cumulative_value": daily[-1]["cumulative_value"] if daily else None,
+            }
+
+        consumptions: list[dict[str, Any]] = []
+        for (year, month), values in sorted(monthly_consumptions.items(), reverse=True):
+            consumptions.append(
+                {
+                    "date": {"month": month, "year": year},
+                    "readings": [
+                        {
+                            "type": sensor_type,
+                            "value": _decimal_string(value),
+                            "unit": unit,
+                            "additionalValue": None,
+                            "additionalUnit": unit,
+                            "estimated": False,
+                            "comparedConsumption": None,
+                            "comparedCost": None,
+                            "averageConsumption": None,
+                        }
+                        for sensor_type, (value, unit) in values.items()
+                    ],
+                }
+            )
+        self._consumption_cache = {"consumptions": consumptions, "costs": []}
+
+        return {
+            "meters": normalized_meters,
+            "aggregates": aggregates,
+        }
+
+    def get_consumption_data(self, obj_uuid: str | None = None) -> dict[str, Any]:
+        """Normalize Czech chart readings to the German API shape reused by ``consum_raw``."""
+        del obj_uuid
+        if self._consumption_cache is not None:
+            return copy.deepcopy(self._consumption_cache)
+        if not self._meters:
+            self._meters = self._get_meters()
+
+        today = date.today()
+        start = _add_months(today, -12)
+        grouped: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
+        requested_types: set[str] = set()
+
+        for meter in self._meters:
+            meter_type = str(_value_case_insensitive(meter, "MeterType", "")).strip().lower()
+            sensor_type = _classify_meter(meter, meter_type)
+            if not meter_type or not sensor_type or meter_type.casefold() in requested_types:
+                continue
+            requested_types.add(meter_type.casefold())
+
+            readings_list = self._get_readings(meter_type, start, today)
+            if not readings_list:
+                continue
+            unit = _normalize_unit(
+                _value_case_insensitive(
+                    readings_list,
+                    "Unit",
+                    _value_case_insensitive(meter, "Unit", ""),
+                ),
+                sensor_type,
+            )
+            readings = _value_case_insensitive(readings_list, "Readings", [])
+            if not isinstance(readings, list):
+                continue
+
+            for reading in readings:
+                if not isinstance(reading, dict):
+                    continue
+                reading_date = _parse_reading_date(
+                    _value_case_insensitive(reading, "Date", _value_case_insensitive(reading, "Name"))
+                )
+                value = _as_decimal(_value_case_insensitive(reading, "Value"))
+                if reading_date is None or value is None:
+                    continue
+
+                values_for_month = grouped[(reading_date.year, reading_date.month)]
+                current = values_for_month.get(sensor_type)
+                if current is None:
+                    values_for_month[sensor_type] = (value, unit)
+                elif current[1] == unit:
+                    values_for_month[sensor_type] = (current[0] + value, unit)
+                else:
+                    _LOGGER.debug(
+                        "Skipping duplicate Czech ista %s value with incompatible units %s/%s",
+                        sensor_type,
+                        current[1],
+                        unit,
+                    )
+
+        consumptions: list[dict[str, Any]] = []
+        for (year, month), values in sorted(grouped.items(), reverse=True):
+            normalized_readings = [
+                {
+                    "type": sensor_type,
+                    "value": _decimal_string(value),
+                    "unit": unit,
+                    "additionalValue": None,
+                    "additionalUnit": unit,
+                    "estimated": False,
+                    "comparedConsumption": None,
+                    "comparedCost": None,
+                    "averageConsumption": None,
+                }
+                for sensor_type, (value, unit) in values.items()
+            ]
+            consumptions.append(
+                {
+                    "date": {"month": month, "year": year},
+                    "readings": normalized_readings,
+                }
+            )
+
+        result = {
+            "consumptions": consumptions,
+            "costs": [],
+        }
+        self._consumption_cache = result
+        return copy.deepcopy(result)

--- a/custom_components/ecotrend_ista/czech_client.py
+++ b/custom_components/ecotrend_ista/czech_client.py
@@ -30,10 +30,27 @@ CZECH_APP_VERSION = "3.2.1"
 _REQUEST_TIMEOUT = 30
 _PERIOD_MONTHLY_HISTORY = 2
 _PERIOD_DAILY_HISTORY = 4
+_MAX_METER_TYPES = 16
+_MAX_READINGS_PER_RESPONSE = 5_000
+_MAX_DECIMAL_DIGITS = 32
+_MAX_DECIMAL_ADJUSTED_EXPONENT = 18
+_MAX_RENDERED_DECIMAL_DIGITS = 40
+_MAX_RENDERED_DECIMAL_ADJUSTED_EXPONENT = 24
+_MIN_DECIMAL_EXPONENT = -12
 _DOTNET_DATE = re.compile(r"^/Date\((?P<milliseconds>-?\d+)")
 _LOGIN_KDF_PASSWORD = "P@%5w0r]>3mll04##22"
 _LOGIN_KDF_SALT = "(&(HBB%J&Y*B1-3mll04##22"
 _CUBIC_METRE_UNITS = {"cbm", "cubicmeter", "cubicmetre", "m3", "m³"}
+_HEATING_UNIT_ALIASES = {
+    "díl",
+    "dílků",
+    "jednotka",
+    "jednotky",
+    "jednotek",
+    "unit",
+    "units",
+}
+_HEATING_UNIT = "jednotek"
 
 
 def _value_case_insensitive(data: dict[str, Any], key: str, default: Any = None) -> Any:
@@ -138,33 +155,64 @@ def _parse_reading_date(value: Any) -> datetime | None:
     return None
 
 
+def _is_supported_decimal(
+    value: Decimal,
+    *,
+    max_digits: int = _MAX_DECIMAL_DIGITS,
+    max_adjusted_exponent: int = _MAX_DECIMAL_ADJUSTED_EXPONENT,
+) -> bool:
+    """Return whether a provider number is finite and safe to render."""
+    if not value.is_finite():
+        return False
+
+    _sign, digits, exponent = value.as_tuple()
+    return (
+        isinstance(exponent, int)
+        and len(digits) <= max_digits
+        and exponent >= _MIN_DECIMAL_EXPONENT
+        and value.adjusted() <= max_adjusted_exponent
+    )
+
+
 def _as_decimal(value: Any) -> Decimal | None:
-    """Convert API numbers, including comma-decimal strings, to Decimal."""
+    """Convert a bounded API number, including comma-decimal strings, to Decimal."""
     if value is None or isinstance(value, bool):
         return None
     if isinstance(value, Decimal):
-        return value
-    if isinstance(value, (int, float)):
-        return Decimal(str(value))
-    if not isinstance(value, str):
-        return None
-
-    normalized = value.strip().replace("\u00a0", "").replace(" ", "")
-    if not normalized:
-        return None
-    if "," in normalized and "." in normalized:
-        normalized = normalized.replace(".", "").replace(",", ".")
+        decimal_value = value
+    elif isinstance(value, (int, float)):
+        decimal_value = Decimal(str(value))
+    elif isinstance(value, str):
+        normalized = value.strip().replace("\u00a0", "").replace(" ", "")
+        if not normalized:
+            return None
+        if "," in normalized and "." in normalized:
+            normalized = normalized.replace(".", "").replace(",", ".")
+        else:
+            normalized = normalized.replace(",", ".")
+        try:
+            decimal_value = Decimal(normalized)
+        except InvalidOperation:
+            return None
     else:
-        normalized = normalized.replace(",", ".")
-    try:
-        return Decimal(normalized)
-    except InvalidOperation:
         return None
 
+    return decimal_value if _is_supported_decimal(decimal_value) else None
 
-def _decimal_string(value: Decimal) -> str:
-    """Return a representation compatible with the existing German parser."""
-    result = format(value, "f")
+
+def _decimal_string(value: Decimal) -> str | None:
+    """Return a bounded representation compatible with the German parser."""
+    if not _is_supported_decimal(
+        value,
+        max_digits=_MAX_RENDERED_DECIMAL_DIGITS,
+        max_adjusted_exponent=_MAX_RENDERED_DECIMAL_ADJUSTED_EXPONENT,
+    ):
+        return None
+
+    try:
+        result = format(value, "f")
+    except (InvalidOperation, ValueError):
+        return None
     if "." in result:
         result = result.rstrip("0").rstrip(".")
     return result or "0"
@@ -175,17 +223,26 @@ def _identifier_string(value: Any) -> str:
     if isinstance(value, str):
         return value.strip()
     decimal_value = _as_decimal(value)
-    if decimal_value is not None:
-        return _decimal_string(decimal_value)
+    if decimal_value is not None and (decimal_text := _decimal_string(decimal_value)) is not None:
+        return decimal_text
     return str(value)
 
 
+def _account_identifier(username: str, instance_id: Any) -> str:
+    """Return a stable account identifier without exposing the login name."""
+    login_hash = hashlib.sha256(username.strip().casefold().encode()).hexdigest()[:12]
+    instance_part = re.sub(r"[^a-z0-9]+", "-", _identifier_string(instance_id).casefold()).strip("-")
+    return f"cz-{instance_part}-{login_hash}" if instance_part else f"cz-{login_hash}"
+
+
 def _normalize_unit(value: Any, sensor_type: str) -> str:
-    """Normalize water volume aliases to the Home Assistant cubic-metre unit."""
+    """Normalize API unit aliases to stable Home Assistant units."""
     unit = str(value or "").strip()
-    compact = re.sub(r"[\s._-]+", "", unit.casefold())
+    compact = re.sub(r"[\s._()/-]+", "", unit.casefold())
     if sensor_type in {"warmwater", "water"} and compact in _CUBIC_METRE_UNITS:
         return "m³"
+    if sensor_type == "heating" and compact in _HEATING_UNIT_ALIASES:
+        return _HEATING_UNIT
     return unit
 
 
@@ -280,9 +337,10 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
         self._access_token = str(access_token)
 
         instance_id = _value_case_insensitive(token_data, "InstanceId")
-        if instance_id in (None, "", 0, "0"):
-            instance_id = hashlib.sha256(self._email.encode()).hexdigest()[:12]
-        self._uuid = f"cz-{instance_id}"
+        self._uuid = _account_identifier(
+            self._email,
+            "" if instance_id in (None, "", 0, "0") else instance_id,
+        )
         self._support_code = self._uuid
         self._account = {
             "firstName": _value_case_insensitive(token_data, "FirstName", ""),
@@ -345,10 +403,7 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
         end: date,
         period: int = _PERIOD_MONTHLY_HISTORY,
     ) -> dict[str, Any] | None:
-        url = (
-            f"{CZECH_READING_URL}/{start:%d-%m-%Y}/{end:%d-%m-%Y}/"
-            f"{period}/{quote(meter_type, safe='')}"
-        )
+        url = f"{CZECH_READING_URL}/{start:%d-%m-%Y}/{end:%d-%m-%Y}/{period}/{quote(meter_type, safe='')}"
         response = self.session.get(
             url,
             headers=self._authorization_headers(),
@@ -370,16 +425,16 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
             sensor_type = _classify_meter(meter, meter_type)
             if not meter_type or not sensor_type:
                 continue
-            meter_types.setdefault(meter_type.casefold(), (sensor_type, meter))
+            meter_type_key = meter_type.casefold()
+            if meter_type_key in meter_types or len(meter_types) < _MAX_METER_TYPES:
+                meter_types.setdefault(meter_type_key, (sensor_type, meter))
 
             meter_id = _value_case_insensitive(meter, "METER_ID")
             if not meter_id:
                 meter_number = _value_case_insensitive(meter, "METER_NO")
                 installation_number = _value_case_insensitive(meter, "INST_NO")
                 fallback_parts = [
-                    _identifier_string(part)
-                    for part in (meter_number, installation_number)
-                    if part not in (None, "")
+                    _identifier_string(part) for part in (meter_number, installation_number) if part not in (None, "")
                 ]
                 meter_id = "-".join(fallback_parts) or f"{meter_type}-{index}"
             reading_date = _parse_reading_date(_value_case_insensitive(meter, "Reading_date"))
@@ -392,9 +447,7 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                     "type": sensor_type,
                     "meter_type": meter_type,
                     "meter_number": str(_value_case_insensitive(meter, "METER_NO", "") or ""),
-                    "installation_number": _identifier_string(
-                        _value_case_insensitive(meter, "INST_NO", "") or ""
-                    ),
+                    "installation_number": _identifier_string(_value_case_insensitive(meter, "INST_NO", "") or ""),
                     "room": str(_value_case_insensitive(meter, "ROOM_DESCR", "") or ""),
                     "label": str(
                         _value_case_insensitive(
@@ -407,9 +460,7 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                     "category": str(_value_case_insensitive(meter, "METCAT_LABEL", "") or ""),
                     "unit": unit,
                     "value": _decimal_string(last_reading) if last_reading is not None else None,
-                    "last_consumption": (
-                        _decimal_string(last_consumption) if last_consumption is not None else None
-                    ),
+                    "last_consumption": (_decimal_string(last_consumption) if last_consumption is not None else None),
                     "reading_date": reading_date.isoformat() if reading_date is not None else None,
                     "activation_date": _value_case_insensitive(meter, "Activation_date"),
                     "deactivation_date": _value_case_insensitive(meter, "Deactivation_date"),
@@ -435,8 +486,14 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
             readings = _value_case_insensitive(readings_list, "Readings", [])
             if not isinstance(readings, list):
                 continue
+            if len(readings) > _MAX_READINGS_PER_RESPONSE:
+                _LOGGER.warning(
+                    "Ignoring %s excess Czech ista daily readings for meter type %s",
+                    len(readings) - _MAX_READINGS_PER_RESPONSE,
+                    meter_type,
+                )
 
-            for reading in readings:
+            for reading in readings[:_MAX_READINGS_PER_RESPONSE]:
                 if not isinstance(reading, dict):
                     continue
                 reading_date = _parse_reading_date(_value_case_insensitive(reading, "Date"))
@@ -446,6 +503,8 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                     continue
 
                 day = reading_date.date()
+                if not start <= day <= today:
+                    continue
                 current = grouped_daily[sensor_type].get(day)
                 if current is None:
                     grouped_daily[sensor_type][day] = {
@@ -456,9 +515,7 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                 elif current["unit"] == unit:
                     current["value"] += value
                     if cumulative_value is not None:
-                        current["cumulative_value"] = (
-                            (current["cumulative_value"] or Decimal("0")) + cumulative_value
-                        )
+                        current["cumulative_value"] = (current["cumulative_value"] or Decimal("0")) + cumulative_value
                 else:
                     _LOGGER.debug(
                         "Skipping Czech ista %s daily value with incompatible units %s/%s",
@@ -481,9 +538,7 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                     {
                         "date": day.isoformat(),
                         "value": _decimal_string(value),
-                        "cumulative_value": (
-                            _decimal_string(cumulative_value) if cumulative_value is not None else None
-                        ),
+                        "cumulative_value": (_decimal_string(cumulative_value) if cumulative_value is not None else None),
                     }
                 )
                 monthly_values[(day.year, day.month)] += value
@@ -557,6 +612,8 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
             sensor_type = _classify_meter(meter, meter_type)
             if not meter_type or not sensor_type or meter_type.casefold() in requested_types:
                 continue
+            if len(requested_types) >= _MAX_METER_TYPES:
+                break
             requested_types.add(meter_type.casefold())
 
             readings_list = self._get_readings(meter_type, start, today)
@@ -573,8 +630,14 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
             readings = _value_case_insensitive(readings_list, "Readings", [])
             if not isinstance(readings, list):
                 continue
+            if len(readings) > _MAX_READINGS_PER_RESPONSE:
+                _LOGGER.warning(
+                    "Ignoring %s excess Czech ista monthly readings for meter type %s",
+                    len(readings) - _MAX_READINGS_PER_RESPONSE,
+                    meter_type,
+                )
 
-            for reading in readings:
+            for reading in readings[:_MAX_READINGS_PER_RESPONSE]:
                 if not isinstance(reading, dict):
                     continue
                 reading_date = _parse_reading_date(
@@ -582,6 +645,15 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
                 )
                 value = _as_decimal(_value_case_insensitive(reading, "Value"))
                 if reading_date is None or value is None:
+                    continue
+                if (
+                    not (start.year, start.month)
+                    <= (reading_date.year, reading_date.month)
+                    <= (
+                        today.year,
+                        today.month,
+                    )
+                ):
                     continue
 
                 values_for_month = grouped[(reading_date.year, reading_date.month)]

--- a/custom_components/ecotrend_ista/czech_client.py
+++ b/custom_components/ecotrend_ista/czech_client.py
@@ -38,7 +38,9 @@ _MAX_RENDERED_DECIMAL_DIGITS = 40
 _MAX_RENDERED_DECIMAL_ADJUSTED_EXPONENT = 24
 _MIN_DECIMAL_EXPONENT = -12
 _DOTNET_DATE = re.compile(r"^/Date\((?P<milliseconds>-?\d+)")
-_LOGIN_KDF_PASSWORD = "P@%5w0r]>3mll04##22"
+# Public protocol input copied from the provider's Unity client. It is not an
+# account credential, and every byte is required for a compatible login proof.
+_LOGIN_KDF_INPUT = "P@%5w0r]>3mll04##22"  # NOSONAR
 _LOGIN_KDF_SALT = "(&(HBB%J&Y*B1-3mll04##22"
 _CUBIC_METRE_UNITS = {"cbm", "cubicmeter", "cubicmetre", "m3", "m³"}
 _HEATING_UNIT_ALIASES = {
@@ -107,12 +109,14 @@ def _dotnet_timestamp(value: datetime) -> str:
 
 def _login_proofs(username: str, password: str, now: datetime | None = None) -> tuple[str, str]:
     """Build the two encrypted form values required by the current Czech login endpoint."""
+    # SHA-1 is part of the provider's legacy PBKDF2 wire protocol here. This
+    # derivation does not store passwords or provide transport security (TLS does).
     key_material = PBKDF2HMAC(
-        algorithm=hashes.SHA1(),
+        algorithm=hashes.SHA1(),  # NOSONAR
         length=96,
         salt=_LOGIN_KDF_SALT.encode("ascii"),
         iterations=1000,
-    ).derive(_LOGIN_KDF_PASSWORD.encode("ascii"))
+    ).derive(_LOGIN_KDF_INPUT.encode("ascii"))
 
     # The Unity client first consumes one Rijndael key/IV pair, then uses the
     # second pair for AesCryptoServiceProvider and the transmitted values.
@@ -123,7 +127,9 @@ def _login_proofs(username: str, password: str, now: datetime | None = None) -> 
     def encrypt(value: str) -> str:
         padder = padding.PKCS7(128).padder()
         padded = padder.update(f"{value}_{timestamp}".encode()) + padder.finalize()
-        encryptor = Cipher(algorithms.AES(key), modes.CBC(initialization_vector)).encryptor()
+        # The fixed CBC framing is likewise mandated by the provider's request
+        # format; changing its mode or IV would make the login proof invalid.
+        encryptor = Cipher(algorithms.AES(key), modes.CBC(initialization_vector)).encryptor()  # NOSONAR
         encrypted = encryptor.update(padded) + encryptor.finalize()
         return "".join(f"_{byte}" for byte in encrypted)
 
@@ -270,6 +276,311 @@ def _classify_meter(meter: dict[str, Any], meter_type: str) -> str | None:
     return None
 
 
+def _meter_descriptor(meter: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the provider and normalized types for a supported meter."""
+    meter_type = str(_value_case_insensitive(meter, "MeterType", "")).strip().lower()
+    sensor_type = _classify_meter(meter, meter_type)
+    if not meter_type or not sensor_type:
+        return None
+    return meter_type, sensor_type
+
+
+def _meter_identifier(meter: dict[str, Any], meter_type: str, index: int) -> str:
+    """Return the provider meter ID, with a stable fallback for incomplete records."""
+    meter_id = _value_case_insensitive(meter, "METER_ID")
+    if meter_id:
+        return _identifier_string(meter_id)
+
+    fallback_parts = [
+        _identifier_string(part)
+        for part in (
+            _value_case_insensitive(meter, "METER_NO"),
+            _value_case_insensitive(meter, "INST_NO"),
+        )
+        if part not in (None, "")
+    ]
+    return "-".join(fallback_parts) or f"{meter_type}-{index}"
+
+
+def _normalized_meter(
+    meter: dict[str, Any],
+    index: int,
+    meter_type: str,
+    sensor_type: str,
+) -> dict[str, Any]:
+    """Normalize one physical meter to the Home Assistant payload shape."""
+    reading_date = _parse_reading_date(_value_case_insensitive(meter, "Reading_date"))
+    last_reading = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Reading"))
+    last_consumption = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Consumption"))
+    return {
+        "id": _meter_identifier(meter, meter_type, index),
+        "type": sensor_type,
+        "meter_type": meter_type,
+        "meter_number": str(_value_case_insensitive(meter, "METER_NO", "") or ""),
+        "installation_number": _identifier_string(_value_case_insensitive(meter, "INST_NO", "") or ""),
+        "room": str(_value_case_insensitive(meter, "ROOM_DESCR", "") or ""),
+        "label": str(
+            _value_case_insensitive(
+                meter,
+                "Headline",
+                _value_case_insensitive(meter, "MeterText", ""),
+            )
+            or ""
+        ),
+        "category": str(_value_case_insensitive(meter, "METCAT_LABEL", "") or ""),
+        "unit": _normalize_unit(_value_case_insensitive(meter, "Unit", ""), sensor_type),
+        "value": _decimal_string(last_reading) if last_reading is not None else None,
+        "last_consumption": _decimal_string(last_consumption) if last_consumption is not None else None,
+        "reading_date": reading_date.isoformat() if reading_date is not None else None,
+        "activation_date": _value_case_insensitive(meter, "Activation_date"),
+        "deactivation_date": _value_case_insensitive(meter, "Deactivation_date"),
+    }
+
+
+def _normalized_meters(meters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize every supported physical meter."""
+    normalized: list[dict[str, Any]] = []
+    for index, meter in enumerate(meters, start=1):
+        descriptor = _meter_descriptor(meter)
+        if descriptor is None:
+            continue
+        normalized.append(_normalized_meter(meter, index, *descriptor))
+    return normalized
+
+
+def _supported_meter_types(meters: list[dict[str, Any]]) -> dict[str, tuple[str, dict[str, Any]]]:
+    """Return the first bounded set of unique supported provider meter types."""
+    meter_types: dict[str, tuple[str, dict[str, Any]]] = {}
+    for meter in meters:
+        descriptor = _meter_descriptor(meter)
+        if descriptor is None:
+            continue
+        meter_type, sensor_type = descriptor
+        meter_type_key = meter_type.casefold()
+        if meter_type_key in meter_types:
+            continue
+        if len(meter_types) >= _MAX_METER_TYPES:
+            break
+        meter_types[meter_type_key] = (sensor_type, meter)
+    return meter_types
+
+
+def _reading_series(
+    readings_list: dict[str, Any] | None,
+    meter: dict[str, Any],
+    sensor_type: str,
+    meter_type: str,
+    period_name: str,
+) -> tuple[str, list[Any]] | None:
+    """Return a normalized, bounded reading series from a provider response."""
+    if not readings_list:
+        return None
+    unit = _normalize_unit(
+        _value_case_insensitive(
+            readings_list,
+            "Unit",
+            _value_case_insensitive(meter, "Unit", ""),
+        ),
+        sensor_type,
+    )
+    readings = _value_case_insensitive(readings_list, "Readings", [])
+    if not isinstance(readings, list):
+        return None
+    if len(readings) > _MAX_READINGS_PER_RESPONSE:
+        _LOGGER.warning(
+            "Ignoring %s excess Czech ista %s readings for meter type %s",
+            len(readings) - _MAX_READINGS_PER_RESPONSE,
+            period_name,
+            meter_type,
+        )
+    return unit, readings[:_MAX_READINGS_PER_RESPONSE]
+
+
+def _daily_reading(
+    reading: Any,
+    start: date,
+    end: date,
+) -> tuple[date, Decimal, Decimal | None] | None:
+    """Parse one in-range daily provider reading."""
+    if not isinstance(reading, dict):
+        return None
+    reading_date = _parse_reading_date(_value_case_insensitive(reading, "Date"))
+    value = _as_decimal(_value_case_insensitive(reading, "Value"))
+    if reading_date is None or value is None:
+        return None
+    day = reading_date.date()
+    if not start <= day <= end:
+        return None
+    cumulative_value = _as_decimal(_value_case_insensitive(reading, "AkkumulativValue"))
+    return day, value, cumulative_value
+
+
+def _merge_daily_reading(
+    grouped: dict[str, dict[date, dict[str, Any]]],
+    sensor_type: str,
+    day: date,
+    value: Decimal,
+    cumulative_value: Decimal | None,
+    unit: str,
+) -> None:
+    """Merge one daily reading, rejecting incompatible units."""
+    current = grouped[sensor_type].get(day)
+    if current is None:
+        grouped[sensor_type][day] = {
+            "value": value,
+            "cumulative_value": cumulative_value,
+            "unit": unit,
+        }
+        return
+    if current["unit"] != unit:
+        _LOGGER.debug(
+            "Skipping Czech ista %s daily value with incompatible units %s/%s",
+            sensor_type,
+            current["unit"],
+            unit,
+        )
+        return
+
+    current["value"] += value
+    if cumulative_value is not None:
+        current["cumulative_value"] = (current["cumulative_value"] or Decimal("0")) + cumulative_value
+
+
+def _daily_history(
+    values_by_day: dict[date, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int], Decimal], str]:
+    """Serialize daily readings and calculate their monthly totals."""
+    daily: list[dict[str, Any]] = []
+    monthly_values: dict[tuple[int, int], Decimal] = defaultdict(Decimal)
+    unit = ""
+    for day, values in sorted(values_by_day.items()):
+        unit = str(values["unit"])
+        value = values["value"]
+        cumulative_value = values["cumulative_value"]
+        daily.append(
+            {
+                "date": day.isoformat(),
+                "value": _decimal_string(value),
+                "cumulative_value": _decimal_string(cumulative_value) if cumulative_value is not None else None,
+            }
+        )
+        monthly_values[(day.year, day.month)] += value
+    return daily, monthly_values, unit
+
+
+def _aggregate_summary(
+    unit: str,
+    daily: list[dict[str, Any]],
+    monthly: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Return the latest values alongside the complete bounded histories."""
+    latest_daily = daily[-1] if daily else {}
+    latest_monthly = monthly[-1] if monthly else {}
+    return {
+        "unit": unit,
+        "daily": daily,
+        "monthly": monthly,
+        "daily_value": latest_daily.get("value"),
+        "daily_date": latest_daily.get("date"),
+        "monthly_value": latest_monthly.get("value"),
+        "monthly_year": latest_monthly.get("year"),
+        "monthly_month": latest_monthly.get("month"),
+        "cumulative_value": latest_daily.get("cumulative_value"),
+    }
+
+
+def _build_aggregates(
+    grouped_daily: dict[str, dict[date, dict[str, Any]]],
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[int, int], dict[str, tuple[Decimal, str]]]]:
+    """Build sensor aggregates and the reusable consumption history."""
+    aggregates: dict[str, dict[str, Any]] = {}
+    monthly_consumptions: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
+    for sensor_type, values_by_day in grouped_daily.items():
+        daily, monthly_values, unit = _daily_history(values_by_day)
+        monthly = [
+            {
+                "year": year,
+                "month": month,
+                "value": _decimal_string(value),
+            }
+            for (year, month), value in sorted(monthly_values.items())
+        ]
+        for (year, month), value in monthly_values.items():
+            monthly_consumptions[(year, month)][sensor_type] = (value, unit)
+        aggregates[sensor_type] = _aggregate_summary(unit, daily, monthly)
+    return aggregates, monthly_consumptions
+
+
+def _consumption_reading(sensor_type: str, value: Decimal, unit: str) -> dict[str, Any]:
+    """Return one reading in the German API shape reused by the integration."""
+    return {
+        "type": sensor_type,
+        "value": _decimal_string(value),
+        "unit": unit,
+        "additionalValue": None,
+        "additionalUnit": unit,
+        "estimated": False,
+        "comparedConsumption": None,
+        "comparedCost": None,
+        "averageConsumption": None,
+    }
+
+
+def _consumption_history(
+    grouped: dict[tuple[int, int], dict[str, tuple[Decimal, str]]],
+) -> list[dict[str, Any]]:
+    """Serialize grouped monthly readings in reverse chronological order."""
+    return [
+        {
+            "date": {"month": month, "year": year},
+            "readings": [_consumption_reading(sensor_type, value, unit) for sensor_type, (value, unit) in values.items()],
+        }
+        for (year, month), values in sorted(grouped.items(), reverse=True)
+    ]
+
+
+def _monthly_reading(
+    reading: Any,
+    start: date,
+    end: date,
+) -> tuple[tuple[int, int], Decimal] | None:
+    """Parse one in-range monthly provider reading."""
+    if not isinstance(reading, dict):
+        return None
+    reading_date = _parse_reading_date(_value_case_insensitive(reading, "Date", _value_case_insensitive(reading, "Name")))
+    value = _as_decimal(_value_case_insensitive(reading, "Value"))
+    if reading_date is None or value is None:
+        return None
+    month = (reading_date.year, reading_date.month)
+    if not (start.year, start.month) <= month <= (end.year, end.month):
+        return None
+    return month, value
+
+
+def _merge_monthly_reading(
+    grouped: dict[tuple[int, int], dict[str, tuple[Decimal, str]]],
+    month: tuple[int, int],
+    sensor_type: str,
+    value: Decimal,
+    unit: str,
+) -> None:
+    """Merge one monthly reading, rejecting incompatible units."""
+    values_for_month = grouped[month]
+    current = values_for_month.get(sensor_type)
+    if current is None:
+        values_for_month[sensor_type] = (value, unit)
+        return
+    if current[1] != unit:
+        _LOGGER.debug(
+            "Skipping duplicate Czech ista %s value with incompatible units %s/%s",
+            sensor_type,
+            current[1],
+            unit,
+        )
+        return
+    values_for_month[sensor_type] = (current[0] + value, unit)
+
+
 class CzechPyEcotrendIsta(PyEcotrendIsta):
     """Expose the Czech/Nordic service through the interface used by the integration."""
 
@@ -413,184 +724,77 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
         readings = _unwrap_value(response.json(), "readingsList")
         return readings if isinstance(readings, dict) else None
 
+    def _daily_groups(
+        self,
+        meter_types: dict[str, tuple[str, dict[str, Any]]],
+        start: date,
+        end: date,
+    ) -> dict[str, dict[date, dict[str, Any]]]:
+        """Load, validate and group daily readings for supported meter types."""
+        grouped: dict[str, dict[date, dict[str, Any]]] = defaultdict(dict)
+        for meter_type, (sensor_type, meter) in meter_types.items():
+            series = _reading_series(
+                self._get_readings(meter_type, start, end, _PERIOD_DAILY_HISTORY),
+                meter,
+                sensor_type,
+                meter_type,
+                "daily",
+            )
+            if series is None:
+                continue
+            unit, readings = series
+            for reading in readings:
+                parsed = _daily_reading(reading, start, end)
+                if parsed is None:
+                    continue
+                day, value, cumulative_value = parsed
+                _merge_daily_reading(grouped, sensor_type, day, value, cumulative_value, unit)
+        return grouped
+
+    def _monthly_groups(
+        self,
+        meter_types: dict[str, tuple[str, dict[str, Any]]],
+        start: date,
+        end: date,
+    ) -> dict[tuple[int, int], dict[str, tuple[Decimal, str]]]:
+        """Load, validate and group monthly readings for supported meter types."""
+        grouped: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
+        for meter_type, (sensor_type, meter) in meter_types.items():
+            series = _reading_series(
+                self._get_readings(meter_type, start, end),
+                meter,
+                sensor_type,
+                meter_type,
+                "monthly",
+            )
+            if series is None:
+                continue
+            unit, readings = series
+            for reading in readings:
+                parsed = _monthly_reading(reading, start, end)
+                if parsed is None:
+                    continue
+                month, value = parsed
+                _merge_monthly_reading(grouped, month, sensor_type, value, unit)
+        return grouped
+
     def get_home_assistant_data(self) -> dict[str, Any]:
         """Return physical meters and daily/monthly aggregate histories for Home Assistant."""
         if not self._meters:
             self._meters = self._get_meters()
 
-        normalized_meters: list[dict[str, Any]] = []
-        meter_types: dict[str, tuple[str, dict[str, Any]]] = {}
-        for index, meter in enumerate(self._meters, start=1):
-            meter_type = str(_value_case_insensitive(meter, "MeterType", "")).strip().lower()
-            sensor_type = _classify_meter(meter, meter_type)
-            if not meter_type or not sensor_type:
-                continue
-            meter_type_key = meter_type.casefold()
-            if meter_type_key in meter_types or len(meter_types) < _MAX_METER_TYPES:
-                meter_types.setdefault(meter_type_key, (sensor_type, meter))
-
-            meter_id = _value_case_insensitive(meter, "METER_ID")
-            if not meter_id:
-                meter_number = _value_case_insensitive(meter, "METER_NO")
-                installation_number = _value_case_insensitive(meter, "INST_NO")
-                fallback_parts = [
-                    _identifier_string(part) for part in (meter_number, installation_number) if part not in (None, "")
-                ]
-                meter_id = "-".join(fallback_parts) or f"{meter_type}-{index}"
-            reading_date = _parse_reading_date(_value_case_insensitive(meter, "Reading_date"))
-            last_reading = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Reading"))
-            last_consumption = _as_decimal(_value_case_insensitive(meter, "Last_Meter_Consumption"))
-            unit = _normalize_unit(_value_case_insensitive(meter, "Unit", ""), sensor_type)
-            normalized_meters.append(
-                {
-                    "id": _identifier_string(meter_id),
-                    "type": sensor_type,
-                    "meter_type": meter_type,
-                    "meter_number": str(_value_case_insensitive(meter, "METER_NO", "") or ""),
-                    "installation_number": _identifier_string(_value_case_insensitive(meter, "INST_NO", "") or ""),
-                    "room": str(_value_case_insensitive(meter, "ROOM_DESCR", "") or ""),
-                    "label": str(
-                        _value_case_insensitive(
-                            meter,
-                            "Headline",
-                            _value_case_insensitive(meter, "MeterText", ""),
-                        )
-                        or ""
-                    ),
-                    "category": str(_value_case_insensitive(meter, "METCAT_LABEL", "") or ""),
-                    "unit": unit,
-                    "value": _decimal_string(last_reading) if last_reading is not None else None,
-                    "last_consumption": (_decimal_string(last_consumption) if last_consumption is not None else None),
-                    "reading_date": reading_date.isoformat() if reading_date is not None else None,
-                    "activation_date": _value_case_insensitive(meter, "Activation_date"),
-                    "deactivation_date": _value_case_insensitive(meter, "Deactivation_date"),
-                }
-            )
-
         today = date.today()
         start = _add_months(today, -12)
-        grouped_daily: dict[str, dict[date, dict[str, Any]]] = defaultdict(dict)
-
-        for meter_type, (sensor_type, meter) in meter_types.items():
-            readings_list = self._get_readings(meter_type, start, today, _PERIOD_DAILY_HISTORY)
-            if not readings_list:
-                continue
-            unit = _normalize_unit(
-                _value_case_insensitive(
-                    readings_list,
-                    "Unit",
-                    _value_case_insensitive(meter, "Unit", ""),
-                ),
-                sensor_type,
-            )
-            readings = _value_case_insensitive(readings_list, "Readings", [])
-            if not isinstance(readings, list):
-                continue
-            if len(readings) > _MAX_READINGS_PER_RESPONSE:
-                _LOGGER.warning(
-                    "Ignoring %s excess Czech ista daily readings for meter type %s",
-                    len(readings) - _MAX_READINGS_PER_RESPONSE,
-                    meter_type,
-                )
-
-            for reading in readings[:_MAX_READINGS_PER_RESPONSE]:
-                if not isinstance(reading, dict):
-                    continue
-                reading_date = _parse_reading_date(_value_case_insensitive(reading, "Date"))
-                value = _as_decimal(_value_case_insensitive(reading, "Value"))
-                cumulative_value = _as_decimal(_value_case_insensitive(reading, "AkkumulativValue"))
-                if reading_date is None or value is None:
-                    continue
-
-                day = reading_date.date()
-                if not start <= day <= today:
-                    continue
-                current = grouped_daily[sensor_type].get(day)
-                if current is None:
-                    grouped_daily[sensor_type][day] = {
-                        "value": value,
-                        "cumulative_value": cumulative_value,
-                        "unit": unit,
-                    }
-                elif current["unit"] == unit:
-                    current["value"] += value
-                    if cumulative_value is not None:
-                        current["cumulative_value"] = (current["cumulative_value"] or Decimal("0")) + cumulative_value
-                else:
-                    _LOGGER.debug(
-                        "Skipping Czech ista %s daily value with incompatible units %s/%s",
-                        sensor_type,
-                        current["unit"],
-                        unit,
-                    )
-
-        aggregates: dict[str, dict[str, Any]] = {}
-        monthly_consumptions: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
-        for sensor_type, values_by_day in grouped_daily.items():
-            daily: list[dict[str, Any]] = []
-            monthly_values: dict[tuple[int, int], Decimal] = defaultdict(Decimal)
-            unit = ""
-            for day, values in sorted(values_by_day.items()):
-                unit = str(values["unit"])
-                value = values["value"]
-                cumulative_value = values["cumulative_value"]
-                daily.append(
-                    {
-                        "date": day.isoformat(),
-                        "value": _decimal_string(value),
-                        "cumulative_value": (_decimal_string(cumulative_value) if cumulative_value is not None else None),
-                    }
-                )
-                monthly_values[(day.year, day.month)] += value
-
-            monthly = [
-                {
-                    "year": year,
-                    "month": month,
-                    "value": _decimal_string(value),
-                }
-                for (year, month), value in sorted(monthly_values.items())
-            ]
-            for (year, month), value in monthly_values.items():
-                monthly_consumptions[(year, month)][sensor_type] = (value, unit)
-
-            aggregates[sensor_type] = {
-                "unit": unit,
-                "daily": daily,
-                "monthly": monthly,
-                "daily_value": daily[-1]["value"] if daily else None,
-                "daily_date": daily[-1]["date"] if daily else None,
-                "monthly_value": monthly[-1]["value"] if monthly else None,
-                "monthly_year": monthly[-1]["year"] if monthly else None,
-                "monthly_month": monthly[-1]["month"] if monthly else None,
-                "cumulative_value": daily[-1]["cumulative_value"] if daily else None,
-            }
-
-        consumptions: list[dict[str, Any]] = []
-        for (year, month), values in sorted(monthly_consumptions.items(), reverse=True):
-            consumptions.append(
-                {
-                    "date": {"month": month, "year": year},
-                    "readings": [
-                        {
-                            "type": sensor_type,
-                            "value": _decimal_string(value),
-                            "unit": unit,
-                            "additionalValue": None,
-                            "additionalUnit": unit,
-                            "estimated": False,
-                            "comparedConsumption": None,
-                            "comparedCost": None,
-                            "averageConsumption": None,
-                        }
-                        for sensor_type, (value, unit) in values.items()
-                    ],
-                }
-            )
-        self._consumption_cache = {"consumptions": consumptions, "costs": []}
+        meter_types = _supported_meter_types(self._meters)
+        grouped_daily = self._daily_groups(meter_types, start, today)
+        aggregates, monthly_consumptions = _build_aggregates(grouped_daily)
+        self._consumption_cache = {
+            "consumptions": _consumption_history(monthly_consumptions),
+            "costs": [],
+        }
 
         return {
-            "meters": normalized_meters,
+            "meters": _normalized_meters(self._meters),
             "aggregates": aggregates,
         }
 
@@ -604,97 +808,10 @@ class CzechPyEcotrendIsta(PyEcotrendIsta):
 
         today = date.today()
         start = _add_months(today, -12)
-        grouped: dict[tuple[int, int], dict[str, tuple[Decimal, str]]] = defaultdict(dict)
-        requested_types: set[str] = set()
-
-        for meter in self._meters:
-            meter_type = str(_value_case_insensitive(meter, "MeterType", "")).strip().lower()
-            sensor_type = _classify_meter(meter, meter_type)
-            if not meter_type or not sensor_type or meter_type.casefold() in requested_types:
-                continue
-            if len(requested_types) >= _MAX_METER_TYPES:
-                break
-            requested_types.add(meter_type.casefold())
-
-            readings_list = self._get_readings(meter_type, start, today)
-            if not readings_list:
-                continue
-            unit = _normalize_unit(
-                _value_case_insensitive(
-                    readings_list,
-                    "Unit",
-                    _value_case_insensitive(meter, "Unit", ""),
-                ),
-                sensor_type,
-            )
-            readings = _value_case_insensitive(readings_list, "Readings", [])
-            if not isinstance(readings, list):
-                continue
-            if len(readings) > _MAX_READINGS_PER_RESPONSE:
-                _LOGGER.warning(
-                    "Ignoring %s excess Czech ista monthly readings for meter type %s",
-                    len(readings) - _MAX_READINGS_PER_RESPONSE,
-                    meter_type,
-                )
-
-            for reading in readings[:_MAX_READINGS_PER_RESPONSE]:
-                if not isinstance(reading, dict):
-                    continue
-                reading_date = _parse_reading_date(
-                    _value_case_insensitive(reading, "Date", _value_case_insensitive(reading, "Name"))
-                )
-                value = _as_decimal(_value_case_insensitive(reading, "Value"))
-                if reading_date is None or value is None:
-                    continue
-                if (
-                    not (start.year, start.month)
-                    <= (reading_date.year, reading_date.month)
-                    <= (
-                        today.year,
-                        today.month,
-                    )
-                ):
-                    continue
-
-                values_for_month = grouped[(reading_date.year, reading_date.month)]
-                current = values_for_month.get(sensor_type)
-                if current is None:
-                    values_for_month[sensor_type] = (value, unit)
-                elif current[1] == unit:
-                    values_for_month[sensor_type] = (current[0] + value, unit)
-                else:
-                    _LOGGER.debug(
-                        "Skipping duplicate Czech ista %s value with incompatible units %s/%s",
-                        sensor_type,
-                        current[1],
-                        unit,
-                    )
-
-        consumptions: list[dict[str, Any]] = []
-        for (year, month), values in sorted(grouped.items(), reverse=True):
-            normalized_readings = [
-                {
-                    "type": sensor_type,
-                    "value": _decimal_string(value),
-                    "unit": unit,
-                    "additionalValue": None,
-                    "additionalUnit": unit,
-                    "estimated": False,
-                    "comparedConsumption": None,
-                    "comparedCost": None,
-                    "averageConsumption": None,
-                }
-                for sensor_type, (value, unit) in values.items()
-            ]
-            consumptions.append(
-                {
-                    "date": {"month": month, "year": year},
-                    "readings": normalized_readings,
-                }
-            )
-
+        meter_types = _supported_meter_types(self._meters)
+        grouped = self._monthly_groups(meter_types, start, today)
         result = {
-            "consumptions": consumptions,
+            "consumptions": _consumption_history(grouped),
             "costs": [],
         }
         self._consumption_cache = result

--- a/custom_components/ecotrend_ista/czech_sensor.py
+++ b/custom_components/ecotrend_ista/czech_sensor.py
@@ -276,6 +276,7 @@ class CzechAggregateSensor(CzechEcotrendSensorEntity):
         coordinator: IstaDataUpdateCoordinator,
         consumption_type: str,
         period: str,
+        translation_key: str,
     ) -> None:
         """Initialize an aggregate sensor."""
         super().__init__(coordinator)
@@ -290,7 +291,7 @@ class CzechAggregateSensor(CzechEcotrendSensorEntity):
             and _unit(initial_aggregate.get("unit"), consumption_type) == _HEATING_UNIT
         )
         self._attr_translation_key = (
-            _AGGREGATE_TRANSLATION_KEYS[(consumption_type, period)]
+            translation_key
             if consumption_type != "heating" or self._uses_translated_heating_unit
             else _HEATING_NATIVE_UNIT_TRANSLATION_KEYS[period]
         )
@@ -412,8 +413,8 @@ def create_czech_sensor_entities(
 
     available_types = _available_consumption_types(data)
     entities.extend(
-        CzechAggregateSensor(coordinator, consumption_type, period)
-        for consumption_type, period in _AGGREGATE_TRANSLATION_KEYS
+        CzechAggregateSensor(coordinator, consumption_type, period, translation_key)
+        for (consumption_type, period), translation_key in _AGGREGATE_TRANSLATION_KEYS.items()
         if consumption_type in available_types
     )
     entities.append(CzechDataFreshnessSensor(coordinator))

--- a/custom_components/ecotrend_ista/czech_sensor.py
+++ b/custom_components/ecotrend_ista/czech_sensor.py
@@ -17,14 +17,23 @@ from .const import DOMAIN, MANUFACTURER
 from .coordinator import IstaDataUpdateCoordinator
 from .czech_statistics import statistic_id
 
-_CONSUMPTION_NAMES = {
-    "heating": "Topení",
-    "warmwater": "Teplá voda",
-    "water": "Studená voda",
+_METER_TRANSLATION_KEYS = {
+    "heating": "czech_heating_meter",
+    "warmwater": "czech_warm_water_meter",
+    "water": "czech_cold_water_meter",
 }
-_PERIOD_NAMES = {
-    "daily": "denní",
-    "monthly": "měsíční",
+_AGGREGATE_TRANSLATION_KEYS = {
+    ("heating", "daily"): "czech_heating_daily",
+    ("heating", "monthly"): "czech_heating_monthly",
+    ("warmwater", "daily"): "czech_warm_water_daily",
+    ("warmwater", "monthly"): "czech_warm_water_monthly",
+    ("water", "daily"): "czech_cold_water_daily",
+    ("water", "monthly"): "czech_cold_water_monthly",
+}
+_HEATING_NATIVE_UNIT_TRANSLATION_KEYS = {
+    "meter": "czech_heating_meter_native_unit",
+    "daily": "czech_heating_daily_native_unit",
+    "monthly": "czech_heating_monthly_native_unit",
 }
 _WATER_TYPES = {"warmwater", "water"}
 _CUBIC_METRE_UNITS = {
@@ -34,6 +43,16 @@ _CUBIC_METRE_UNITS = {
     "m3",
     "m³",
 }
+_HEATING_UNIT_ALIASES = {
+    "díl",
+    "dílků",
+    "jednotka",
+    "jednotky",
+    "jednotek",
+    "unit",
+    "units",
+}
+_HEATING_UNIT = "jednotek"
 
 
 def _czech_data(coordinator: IstaDataUpdateCoordinator) -> dict[str, Any]:
@@ -85,46 +104,78 @@ def _number(value: Any) -> StateType:
 
 
 def _unit(unit: Any, consumption_type: str) -> str | None:
-    """Normalize Czech water-volume units to the Home Assistant unit."""
+    """Normalize Czech API units for Home Assistant."""
     if unit is None:
         return None
     value = str(unit).strip()
     if not value:
         return None
-    compact = re.sub(r"[\s._-]+", "", value.casefold())
+    compact = re.sub(r"[\s._()/-]+", "", value.casefold())
     if consumption_type in _WATER_TYPES and compact in _CUBIC_METRE_UNITS:
         return UnitOfVolume.CUBIC_METERS
+    if consumption_type == "heating" and compact in _HEATING_UNIT_ALIASES:
+        return _HEATING_UNIT
     return value
 
 
-def _period_start(aggregate: dict[str, Any], period: str) -> datetime | None:
-    """Return the local start of the latest represented interval."""
-    if period == "daily":
-        raw_date = aggregate.get("daily_date")
-        if not raw_date:
-            return None
-        try:
-            interval_date = date.fromisoformat(str(raw_date))
-        except ValueError:
-            return None
-        return datetime(
-            interval_date.year,
-            interval_date.month,
-            interval_date.day,
-            tzinfo=dt_util.DEFAULT_TIME_ZONE,
-        )
-
-    try:
-        year = int(aggregate["monthly_year"])
-        month = int(aggregate["monthly_month"])
-        return datetime(year, month, 1, tzinfo=dt_util.DEFAULT_TIME_ZONE)
-    except (KeyError, TypeError, ValueError):
+def _latest_data_date(aggregate: dict[str, Any]) -> date | None:
+    """Return the latest daily date represented by an aggregate."""
+    raw_date = aggregate.get("daily_date")
+    if not raw_date:
         return None
+    try:
+        return date.fromisoformat(str(raw_date))
+    except ValueError:
+        return None
+
+
+def _data_delay_days(data_date: date | None) -> int | None:
+    """Return how many local calendar days the available data trails today."""
+    if data_date is None:
+        return None
+    today = datetime.now(tz=dt_util.DEFAULT_TIME_ZONE).date()
+    return max(0, (today - data_date).days)
 
 
 def _defined_attributes(values: dict[str, Any]) -> dict[str, Any]:
     """Remove empty metadata values from state attributes."""
     return {key: value for key, value in values.items() if value not in (None, "")}
+
+
+def _available_consumption_types(data: dict[str, Any]) -> set[str]:
+    """Return consumption types represented by meters or aggregate data."""
+    consumption_types: set[str] = set()
+    meters = data.get("meters")
+    if isinstance(meters, list):
+        consumption_types.update(
+            str(meter["type"]) for meter in meters if isinstance(meter, dict) and meter.get("type") in _METER_TRANSLATION_KEYS
+        )
+
+    aggregates = data.get("aggregates")
+    if isinstance(aggregates, dict):
+        consumption_types.update(
+            consumption_type for consumption_type in aggregates if consumption_type in _METER_TRANSLATION_KEYS
+        )
+    return consumption_types
+
+
+def _meter_lookup(coordinator: IstaDataUpdateCoordinator) -> dict[tuple[str, str], dict[str, Any]]:
+    """Return an O(1) meter lookup cached for the current coordinator payload."""
+    meters = _czech_data(coordinator).get("meters", [])
+    if not isinstance(meters, list):
+        return {}
+
+    cache = getattr(coordinator, "_czech_meter_lookup_cache", None)
+    if isinstance(cache, tuple) and len(cache) == 2 and cache[0] is meters:
+        return cache[1]
+
+    lookup = {
+        (str(meter.get("type")), str(meter.get("id"))): meter
+        for meter in meters
+        if isinstance(meter, dict) and meter.get("id") is not None
+    }
+    coordinator._czech_meter_lookup_cache = (meters, lookup)
+    return lookup
 
 
 class CzechEcotrendSensorEntity(CoordinatorEntity[IstaDataUpdateCoordinator], SensorEntity):
@@ -162,33 +213,28 @@ class CzechPhysicalMeterSensor(CzechEcotrendSensorEntity):
         self._meter_id = str(meter["id"])
         self._consumption_type = str(meter["type"])
         unique_meter_id = _unique_id_part(self._meter_id)
-        self._attr_unique_id = (
-            f"{_unique_id_part(self._account_id)}_meter_{self._consumption_type}_{unique_meter_id}"
-        )
+        self._attr_unique_id = f"{_unique_id_part(self._account_id)}_meter_{self._consumption_type}_{unique_meter_id}"
 
-        type_name = _CONSUMPTION_NAMES.get(self._consumption_type, self._consumption_type.title())
         meter_number = meter.get("meter_number")
         detail = meter.get("room") or meter.get("label") or meter_number or self._meter_id
         if meter_number and meter_number != detail:
             detail = f"{detail} ({meter_number})"
-        self._attr_name = f"{type_name} {detail}"
+        self._uses_translated_heating_unit = (
+            self._consumption_type == "heating" and _unit(meter.get("unit"), self._consumption_type) == _HEATING_UNIT
+        )
+        self._attr_translation_key = (
+            _METER_TRANSLATION_KEYS[self._consumption_type]
+            if self._consumption_type != "heating" or self._uses_translated_heating_unit
+            else _HEATING_NATIVE_UNIT_TRANSLATION_KEYS["meter"]
+        )
+        self._attr_translation_placeholders = {"detail": str(detail)}
         if self._consumption_type in _WATER_TYPES:
             self._attr_device_class = SensorDeviceClass.WATER
 
     @property
     def _meter(self) -> dict[str, Any]:
         """Return the latest data for this physical meter."""
-        meters = _czech_data(self.coordinator).get("meters", [])
-        if not isinstance(meters, list):
-            return {}
-        for meter in meters:
-            if (
-                isinstance(meter, dict)
-                and str(meter.get("id")) == self._meter_id
-                and str(meter.get("type")) == self._consumption_type
-            ):
-                return meter
-        return {}
+        return _meter_lookup(self.coordinator).get((self._consumption_type, self._meter_id), {})
 
     @property
     def native_value(self) -> StateType:
@@ -198,7 +244,8 @@ class CzechPhysicalMeterSensor(CzechEcotrendSensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the meter unit."""
-        return _unit(self._meter.get("unit"), self._consumption_type)
+        unit = _unit(self._meter.get("unit"), self._consumption_type)
+        return None if self._uses_translated_heating_unit else unit
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -224,8 +271,6 @@ class CzechPhysicalMeterSensor(CzechEcotrendSensorEntity):
 class CzechAggregateSensor(CzechEcotrendSensorEntity):
     """Daily or monthly Czech ista consumption aggregate."""
 
-    _attr_state_class = SensorStateClass.TOTAL
-
     def __init__(
         self,
         coordinator: IstaDataUpdateCoordinator,
@@ -236,11 +281,19 @@ class CzechAggregateSensor(CzechEcotrendSensorEntity):
         super().__init__(coordinator)
         self._consumption_type = consumption_type
         self._period = period
-        self._attr_unique_id = (
-            f"{_unique_id_part(self._account_id)}_{consumption_type}_{period}"
+        self._attr_unique_id = f"{_unique_id_part(self._account_id)}_{consumption_type}_{period}"
+        aggregates = _czech_data(coordinator).get("aggregates", {})
+        initial_aggregate = aggregates.get(consumption_type, {}) if isinstance(aggregates, dict) else {}
+        self._uses_translated_heating_unit = (
+            consumption_type == "heating"
+            and isinstance(initial_aggregate, dict)
+            and _unit(initial_aggregate.get("unit"), consumption_type) == _HEATING_UNIT
         )
-        type_name = _CONSUMPTION_NAMES[consumption_type]
-        self._attr_name = f"{type_name} {_PERIOD_NAMES[period]}"
+        self._attr_translation_key = (
+            _AGGREGATE_TRANSLATION_KEYS[(consumption_type, period)]
+            if consumption_type != "heating" or self._uses_translated_heating_unit
+            else _HEATING_NATIVE_UNIT_TRANSLATION_KEYS[period]
+        )
         if consumption_type in _WATER_TYPES:
             self._attr_device_class = SensorDeviceClass.WATER
 
@@ -261,17 +314,14 @@ class CzechAggregateSensor(CzechEcotrendSensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the aggregate unit."""
-        return _unit(self._aggregate.get("unit"), self._consumption_type)
-
-    @property
-    def last_reset(self) -> datetime | None:
-        """Return the start of the represented daily or monthly interval."""
-        return _period_start(self._aggregate, self._period)
+        unit = _unit(self._aggregate.get("unit"), self._consumption_type)
+        return None if self._uses_translated_heating_unit else unit
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return aggregate metadata without embedding historical readings."""
         aggregate = self._aggregate
+        data_through = _latest_data_date(aggregate)
         if self._period == "daily":
             latest_period = aggregate.get("daily_date")
         else:
@@ -283,10 +333,61 @@ class CzechAggregateSensor(CzechEcotrendSensorEntity):
                 "consumption_type": self._consumption_type,
                 "period": self._period,
                 "latest_period": latest_period,
+                "data_through": data_through.isoformat() if data_through else None,
+                "delay_days": _data_delay_days(data_through),
                 "external_statistic_id": statistic_id(
                     self._account_id,
                     self._consumption_type,
                 ),
+            }
+        )
+
+
+class CzechDataFreshnessSensor(CzechEcotrendSensorEntity):
+    """Latest date through which all available consumption types have data."""
+
+    _attr_device_class = SensorDeviceClass.DATE
+    _attr_translation_key = "czech_data_through"
+
+    def __init__(self, coordinator: IstaDataUpdateCoordinator) -> None:
+        """Initialize the data freshness sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{_unique_id_part(self._account_id)}_data_through"
+
+    @property
+    def _dates_by_type(self) -> dict[str, date | None]:
+        """Return the latest date for every expected consumption type."""
+        data = _czech_data(self.coordinator)
+        aggregates = data.get("aggregates", {})
+        if not isinstance(aggregates, dict):
+            aggregates = {}
+
+        return {
+            consumption_type: (
+                _latest_data_date(aggregate) if isinstance((aggregate := aggregates.get(consumption_type)), dict) else None
+            )
+            for consumption_type in _available_consumption_types(data)
+        }
+
+    @property
+    def native_value(self) -> date | None:
+        """Return the oldest latest date so the value is valid for every type."""
+        dates = list(self._dates_by_type.values())
+        if not dates or any(data_date is None for data_date in dates):
+            return None
+        return min(data_date for data_date in dates if data_date is not None)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose per-type freshness and the effective delay."""
+        dates = self._dates_by_type
+        data_through = self.native_value
+        return _defined_attributes(
+            {
+                "delay_days": _data_delay_days(data_through),
+                "heating_data_through": dates.get("heating").isoformat() if dates.get("heating") else None,
+                "hot_water_data_through": dates.get("warmwater").isoformat() if dates.get("warmwater") else None,
+                "cold_water_data_through": dates.get("water").isoformat() if dates.get("water") else None,
             }
         )
 
@@ -296,11 +397,12 @@ def create_czech_sensor_entities(
 ) -> list[CzechEcotrendSensorEntity]:
     """Create physical and aggregate sensor entities for a Czech account."""
     entities: list[CzechEcotrendSensorEntity] = []
-    meters = _czech_data(coordinator).get("meters", [])
+    data = _czech_data(coordinator)
+    meters = data.get("meters", [])
     seen_meters: set[tuple[str, str]] = set()
     if isinstance(meters, list):
         for meter in meters:
-            if not isinstance(meter, dict) or meter.get("id") is None or meter.get("type") is None:
+            if not isinstance(meter, dict) or meter.get("id") is None or meter.get("type") not in _METER_TRANSLATION_KEYS:
                 continue
             meter_key = (str(meter["type"]), str(meter["id"]))
             if meter_key in seen_meters:
@@ -308,9 +410,11 @@ def create_czech_sensor_entities(
             seen_meters.add(meter_key)
             entities.append(CzechPhysicalMeterSensor(coordinator, meter))
 
+    available_types = _available_consumption_types(data)
     entities.extend(
         CzechAggregateSensor(coordinator, consumption_type, period)
-        for consumption_type in _CONSUMPTION_NAMES
-        for period in _PERIOD_NAMES
+        for consumption_type, period in _AGGREGATE_TRANSLATION_KEYS
+        if consumption_type in available_types
     )
+    entities.append(CzechDataFreshnessSensor(coordinator))
     return entities

--- a/custom_components/ecotrend_ista/czech_sensor.py
+++ b/custom_components/ecotrend_ista/czech_sensor.py
@@ -1,0 +1,316 @@
+"""Sensor entities for Czech ista EcoTrend accounts."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+import re
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.const import UnitOfVolume
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import IstaDataUpdateCoordinator
+from .czech_statistics import statistic_id
+
+_CONSUMPTION_NAMES = {
+    "heating": "Topení",
+    "warmwater": "Teplá voda",
+    "water": "Studená voda",
+}
+_PERIOD_NAMES = {
+    "daily": "denní",
+    "monthly": "měsíční",
+}
+_WATER_TYPES = {"warmwater", "water"}
+_CUBIC_METRE_UNITS = {
+    "cbm",
+    "cubicmeter",
+    "cubicmetre",
+    "m3",
+    "m³",
+}
+
+
+def _czech_data(coordinator: IstaDataUpdateCoordinator) -> dict[str, Any]:
+    """Return the Czech payload regardless of its coordinator storage location."""
+    czech_data = getattr(coordinator, "czech_data", None)
+    if isinstance(czech_data, dict):
+        return czech_data
+
+    coordinator_data = coordinator.data
+    if not isinstance(coordinator_data, dict):
+        return {}
+    if "meters" in coordinator_data or "aggregates" in coordinator_data:
+        return coordinator_data
+
+    for value in coordinator_data.values():
+        if isinstance(value, dict) and ("meters" in value or "aggregates" in value):
+            return value
+    return {}
+
+
+def _account_id(coordinator: IstaDataUpdateCoordinator) -> str:
+    """Return the stable account identifier used by every Czech entity."""
+    support_code = coordinator.controller.get_support_code()
+    if support_code:
+        return str(support_code)
+
+    uuids = coordinator.controller.get_uuids()
+    if uuids:
+        return str(uuids[0])
+    return coordinator.config_entry.entry_id
+
+
+def _unique_id_part(value: Any) -> str:
+    """Normalize an API identifier for use inside an entity unique ID."""
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(value).casefold()).strip("_")
+    return normalized or "unknown"
+
+
+def _number(value: Any) -> StateType:
+    """Convert API numeric strings to sensor-compatible values."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return float(str(value).strip().replace(",", "."))
+    except ValueError:
+        return None
+
+
+def _unit(unit: Any, consumption_type: str) -> str | None:
+    """Normalize Czech water-volume units to the Home Assistant unit."""
+    if unit is None:
+        return None
+    value = str(unit).strip()
+    if not value:
+        return None
+    compact = re.sub(r"[\s._-]+", "", value.casefold())
+    if consumption_type in _WATER_TYPES and compact in _CUBIC_METRE_UNITS:
+        return UnitOfVolume.CUBIC_METERS
+    return value
+
+
+def _period_start(aggregate: dict[str, Any], period: str) -> datetime | None:
+    """Return the local start of the latest represented interval."""
+    if period == "daily":
+        raw_date = aggregate.get("daily_date")
+        if not raw_date:
+            return None
+        try:
+            interval_date = date.fromisoformat(str(raw_date))
+        except ValueError:
+            return None
+        return datetime(
+            interval_date.year,
+            interval_date.month,
+            interval_date.day,
+            tzinfo=dt_util.DEFAULT_TIME_ZONE,
+        )
+
+    try:
+        year = int(aggregate["monthly_year"])
+        month = int(aggregate["monthly_month"])
+        return datetime(year, month, 1, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _defined_attributes(values: dict[str, Any]) -> dict[str, Any]:
+    """Remove empty metadata values from state attributes."""
+    return {key: value for key, value in values.items() if value not in (None, "")}
+
+
+class CzechEcotrendSensorEntity(CoordinatorEntity[IstaDataUpdateCoordinator], SensorEntity):
+    """Base class shared by Czech ista sensor entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: IstaDataUpdateCoordinator) -> None:
+        """Initialize a Czech ista sensor entity."""
+        super().__init__(coordinator)
+        account_id = _account_id(coordinator)
+        self._account_id = account_id
+        self._attr_attribution = "Data provided by https://ecotrend.ista.cz/"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, account_id)},
+            manufacturer=MANUFACTURER,
+            model="ista EcoTrend Czech Republic",
+            name="ista EcoTrend CZ",
+            sw_version=coordinator.controller.get_version(),
+        )
+
+
+class CzechPhysicalMeterSensor(CzechEcotrendSensorEntity):
+    """Current reading of one physical Czech ista meter."""
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self,
+        coordinator: IstaDataUpdateCoordinator,
+        meter: dict[str, Any],
+    ) -> None:
+        """Initialize a physical meter sensor."""
+        super().__init__(coordinator)
+        self._meter_id = str(meter["id"])
+        self._consumption_type = str(meter["type"])
+        unique_meter_id = _unique_id_part(self._meter_id)
+        self._attr_unique_id = (
+            f"{_unique_id_part(self._account_id)}_meter_{self._consumption_type}_{unique_meter_id}"
+        )
+
+        type_name = _CONSUMPTION_NAMES.get(self._consumption_type, self._consumption_type.title())
+        meter_number = meter.get("meter_number")
+        detail = meter.get("room") or meter.get("label") or meter_number or self._meter_id
+        if meter_number and meter_number != detail:
+            detail = f"{detail} ({meter_number})"
+        self._attr_name = f"{type_name} {detail}"
+        if self._consumption_type in _WATER_TYPES:
+            self._attr_device_class = SensorDeviceClass.WATER
+
+    @property
+    def _meter(self) -> dict[str, Any]:
+        """Return the latest data for this physical meter."""
+        meters = _czech_data(self.coordinator).get("meters", [])
+        if not isinstance(meters, list):
+            return {}
+        for meter in meters:
+            if (
+                isinstance(meter, dict)
+                and str(meter.get("id")) == self._meter_id
+                and str(meter.get("type")) == self._consumption_type
+            ):
+                return meter
+        return {}
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the latest physical meter reading."""
+        return _number(self._meter.get("value"))
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the meter unit."""
+        return _unit(self._meter.get("unit"), self._consumption_type)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return physical meter metadata without embedding history."""
+        meter = self._meter
+        return _defined_attributes(
+            {
+                "meter_id": self._meter_id,
+                "meter_type": meter.get("meter_type"),
+                "meter_number": meter.get("meter_number"),
+                "installation_number": meter.get("installation_number"),
+                "room": meter.get("room"),
+                "label": meter.get("label"),
+                "category": meter.get("category"),
+                "reading_date": meter.get("reading_date"),
+                "last_consumption": meter.get("last_consumption"),
+                "activation_date": meter.get("activation_date"),
+                "deactivation_date": meter.get("deactivation_date"),
+            }
+        )
+
+
+class CzechAggregateSensor(CzechEcotrendSensorEntity):
+    """Daily or monthly Czech ista consumption aggregate."""
+
+    _attr_state_class = SensorStateClass.TOTAL
+
+    def __init__(
+        self,
+        coordinator: IstaDataUpdateCoordinator,
+        consumption_type: str,
+        period: str,
+    ) -> None:
+        """Initialize an aggregate sensor."""
+        super().__init__(coordinator)
+        self._consumption_type = consumption_type
+        self._period = period
+        self._attr_unique_id = (
+            f"{_unique_id_part(self._account_id)}_{consumption_type}_{period}"
+        )
+        type_name = _CONSUMPTION_NAMES[consumption_type]
+        self._attr_name = f"{type_name} {_PERIOD_NAMES[period]}"
+        if consumption_type in _WATER_TYPES:
+            self._attr_device_class = SensorDeviceClass.WATER
+
+    @property
+    def _aggregate(self) -> dict[str, Any]:
+        """Return the latest aggregate data for this entity."""
+        aggregates = _czech_data(self.coordinator).get("aggregates", {})
+        if not isinstance(aggregates, dict):
+            return {}
+        aggregate = aggregates.get(self._consumption_type)
+        return aggregate if isinstance(aggregate, dict) else {}
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the latest interval consumption."""
+        return _number(self._aggregate.get(f"{self._period}_value"))
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the aggregate unit."""
+        return _unit(self._aggregate.get("unit"), self._consumption_type)
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented daily or monthly interval."""
+        return _period_start(self._aggregate, self._period)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return aggregate metadata without embedding historical readings."""
+        aggregate = self._aggregate
+        if self._period == "daily":
+            latest_period = aggregate.get("daily_date")
+        else:
+            year = aggregate.get("monthly_year")
+            month = aggregate.get("monthly_month")
+            latest_period = f"{year:04}-{month:02}" if isinstance(year, int) and isinstance(month, int) else None
+        return _defined_attributes(
+            {
+                "consumption_type": self._consumption_type,
+                "period": self._period,
+                "latest_period": latest_period,
+                "external_statistic_id": statistic_id(
+                    self._account_id,
+                    self._consumption_type,
+                ),
+            }
+        )
+
+
+def create_czech_sensor_entities(
+    coordinator: IstaDataUpdateCoordinator,
+) -> list[CzechEcotrendSensorEntity]:
+    """Create physical and aggregate sensor entities for a Czech account."""
+    entities: list[CzechEcotrendSensorEntity] = []
+    meters = _czech_data(coordinator).get("meters", [])
+    seen_meters: set[tuple[str, str]] = set()
+    if isinstance(meters, list):
+        for meter in meters:
+            if not isinstance(meter, dict) or meter.get("id") is None or meter.get("type") is None:
+                continue
+            meter_key = (str(meter["type"]), str(meter["id"]))
+            if meter_key in seen_meters:
+                continue
+            seen_meters.add(meter_key)
+            entities.append(CzechPhysicalMeterSensor(coordinator, meter))
+
+    entities.extend(
+        CzechAggregateSensor(coordinator, consumption_type, period)
+        for consumption_type in _CONSUMPTION_NAMES
+        for period in _PERIOD_NAMES
+    )
+    return entities

--- a/custom_components/ecotrend_ista/czech_statistics.py
+++ b/custom_components/ecotrend_ista/czech_statistics.py
@@ -1,0 +1,228 @@
+"""Persist and import Czech ista daily consumption statistics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, date, datetime, time
+from decimal import Decimal, InvalidOperation
+import re
+from typing import Any
+import unicodedata
+
+from homeassistant.components.recorder.models import StatisticData, StatisticMeanType, StatisticMetaData
+from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+_STORE_VERSION = 1
+_VOLUME_UNIT = "m³"
+_VOLUME_UNIT_CLASS = "volume"
+_STATISTIC_NAMES = {
+    "heating": "Topení",
+    "warmwater": "Teplá voda",
+    "water": "Studená voda",
+}
+
+
+def _slug(value: str, fallback: str) -> str:
+    """Return a Home Assistant compatible slug."""
+    ascii_value = (
+        unicodedata.normalize("NFKD", value)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    slug = re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", ascii_value)).strip("_")
+    return slug or fallback
+
+
+def statistic_id(account_id: str, sensor_type: str) -> str:
+    """Return the external statistic ID for an account and consumption type."""
+    account_slug = _slug(account_id, "account")
+    type_slug = _slug(sensor_type, "consumption")
+    return f"{DOMAIN}:{account_slug}_{type_slug}_daily"
+
+
+def _store_key(account_id: str) -> str:
+    """Return the per-account Home Assistant storage key."""
+    return f"{DOMAIN}.czech_statistics_{_slug(account_id, 'account')}"
+
+
+def _decimal_string(value: Any) -> str | None:
+    """Return a stable decimal representation or None for invalid values."""
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if not decimal_value.is_finite():
+        return None
+    return format(decimal_value.normalize(), "f")
+
+
+def _normalize_store(stored: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Normalize persisted data while discarding malformed values."""
+    normalized: dict[str, Any] = {"types": {}}
+    if not isinstance(stored, Mapping):
+        return normalized
+
+    stored_types = stored.get("types")
+    if not isinstance(stored_types, Mapping):
+        return normalized
+
+    for sensor_type, stored_type in stored_types.items():
+        if not isinstance(sensor_type, str) or not isinstance(stored_type, Mapping):
+            continue
+
+        unit = stored_type.get("unit")
+        daily = stored_type.get("daily")
+        normalized_daily: dict[str, str] = {}
+        if isinstance(daily, Mapping):
+            for day_value, consumption in daily.items():
+                if not isinstance(day_value, str):
+                    continue
+                try:
+                    date.fromisoformat(day_value)
+                except ValueError:
+                    continue
+                if (decimal_value := _decimal_string(consumption)) is not None:
+                    normalized_daily[day_value] = decimal_value
+
+        normalized["types"][sensor_type] = {
+            "unit": unit if isinstance(unit, str) else "",
+            "daily": normalized_daily,
+        }
+
+    return normalized
+
+
+def _merge_daily_history(
+    stored: Mapping[str, Any] | None,
+    aggregates: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, date]]:
+    """Merge API values into stored history and return earliest changed dates."""
+    merged = _normalize_store(stored)
+    earliest_changed: dict[str, date] = {}
+
+    for sensor_type, aggregate in aggregates.items():
+        if not isinstance(sensor_type, str) or not isinstance(aggregate, Mapping):
+            continue
+
+        types = merged["types"]
+        history = types.setdefault(sensor_type, {"unit": "", "daily": {}})
+        daily_history: dict[str, str] = history["daily"]
+
+        unit = aggregate.get("unit")
+        if isinstance(unit, str) and unit != history["unit"]:
+            history["unit"] = unit
+            if daily_history:
+                earliest_changed[sensor_type] = date.fromisoformat(min(daily_history))
+
+        daily = aggregate.get("daily")
+        if not isinstance(daily, list):
+            continue
+
+        for item in daily:
+            if not isinstance(item, Mapping):
+                continue
+            day_value = item.get("date")
+            if not isinstance(day_value, str):
+                continue
+            try:
+                reading_day = date.fromisoformat(day_value)
+            except ValueError:
+                continue
+            if (value := _decimal_string(item.get("value"))) is None:
+                continue
+
+            if daily_history.get(day_value) == value:
+                continue
+
+            daily_history[day_value] = value
+            changed = earliest_changed.get(sensor_type)
+            earliest_changed[sensor_type] = min(changed, reading_day) if changed else reading_day
+
+    return merged, earliest_changed
+
+
+def _statistics_timestamp(reading_day: date) -> datetime:
+    """Return the aligned UTC endpoint within the consumed local calendar day."""
+    interval_end = datetime.combine(
+        reading_day,
+        time(hour=23),
+        tzinfo=dt_util.DEFAULT_TIME_ZONE,
+    ).astimezone(UTC)
+
+    # Recorder accepts only timestamps aligned to the top of an hour. 23:00 keeps
+    # the completed daily value in its calendar day and Czech zones are aligned.
+    return interval_end.replace(minute=0, second=0, microsecond=0)
+
+
+def _build_statistics(
+    daily_history: Mapping[str, str],
+    earliest_changed: date,
+) -> list[StatisticData]:
+    """Build cumulative statistics, including all history in every running sum."""
+    statistics: list[StatisticData] = []
+    running_sum = Decimal("0")
+
+    for day_value in sorted(daily_history):
+        reading_day = date.fromisoformat(day_value)
+        running_sum += Decimal(daily_history[day_value])
+        if reading_day < earliest_changed:
+            continue
+
+        cumulative_value = float(running_sum)
+        statistics.append(
+            {
+                "start": _statistics_timestamp(reading_day),
+                "state": cumulative_value,
+                "sum": cumulative_value,
+            }
+        )
+
+    return statistics
+
+
+def _metadata(account_id: str, sensor_type: str, unit: str) -> StatisticMetaData:
+    """Build recorder metadata for one daily consumption type."""
+    return {
+        "mean_type": StatisticMeanType.NONE,
+        "has_sum": True,
+        "name": f"ista EcoTrend {_STATISTIC_NAMES.get(sensor_type, sensor_type)} spotřeba",
+        "source": DOMAIN,
+        "statistic_id": statistic_id(account_id, sensor_type),
+        "unit_class": _VOLUME_UNIT_CLASS if unit == _VOLUME_UNIT else None,
+        "unit_of_measurement": unit or None,
+    }
+
+
+async def async_sync_czech_statistics(
+    hass: HomeAssistant,
+    account_id: str,
+    aggregates: Mapping[str, Any],
+) -> None:
+    """Merge persisted daily values and upsert changed statistics into recorder."""
+    components = getattr(getattr(hass, "config", None), "components", ())
+    if "recorder" not in components:
+        return
+
+    store = Store(hass, _STORE_VERSION, _store_key(account_id))
+    stored = await store.async_load()
+    merged, earliest_changed = _merge_daily_history(stored, aggregates)
+    if not earliest_changed:
+        return
+
+    for sensor_type, changed_from in earliest_changed.items():
+        history = merged["types"][sensor_type]
+        statistics = _build_statistics(history["daily"], changed_from)
+        if statistics:
+            async_add_external_statistics(
+                hass,
+                _metadata(account_id, sensor_type, history["unit"]),
+                statistics,
+            )
+
+    await store.async_save(merged)

--- a/custom_components/ecotrend_ista/czech_statistics.py
+++ b/custom_components/ecotrend_ista/czech_statistics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC, date, datetime, time
 from decimal import Decimal, InvalidOperation
+import math
 import re
 from typing import Any
 import unicodedata
@@ -18,23 +19,28 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 
 _STORE_VERSION = 1
+_MAX_DECIMAL_DIGITS = 32
+_MAX_DECIMAL_ADJUSTED_EXPONENT = 18
+_MIN_DECIMAL_EXPONENT = -12
 _VOLUME_UNIT = "m³"
 _VOLUME_UNIT_CLASS = "volume"
 _STATISTIC_NAMES = {
-    "heating": "Topení",
-    "warmwater": "Teplá voda",
-    "water": "Studená voda",
+    "en": {
+        "heating": "Heating consumption",
+        "warmwater": "Hot water consumption",
+        "water": "Cold water consumption",
+    },
+    "cs": {
+        "heating": "Spotřeba vytápění",
+        "warmwater": "Spotřeba teplé vody",
+        "water": "Spotřeba studené vody",
+    },
 }
 
 
 def _slug(value: str, fallback: str) -> str:
     """Return a Home Assistant compatible slug."""
-    ascii_value = (
-        unicodedata.normalize("NFKD", value)
-        .encode("ascii", "ignore")
-        .decode("ascii")
-        .lower()
-    )
+    ascii_value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii").lower()
     slug = re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", ascii_value)).strip("_")
     return slug or fallback
 
@@ -52,14 +58,36 @@ def _store_key(account_id: str) -> str:
 
 
 def _decimal_string(value: Any) -> str | None:
-    """Return a stable decimal representation or None for invalid values."""
+    """Return a stable, bounded decimal representation or None."""
     try:
         decimal_value = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return None
     if not decimal_value.is_finite():
         return None
-    return format(decimal_value.normalize(), "f")
+
+    _sign, digits, exponent = decimal_value.as_tuple()
+    if (
+        not isinstance(exponent, int)
+        or len(digits) > _MAX_DECIMAL_DIGITS
+        or exponent < _MIN_DECIMAL_EXPONENT
+        or decimal_value.adjusted() > _MAX_DECIMAL_ADJUSTED_EXPONENT
+    ):
+        return None
+
+    try:
+        return format(decimal_value.normalize(), "f")
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _finite_float(value: Decimal) -> float | None:
+    """Convert a Decimal only when the recorder value remains finite."""
+    try:
+        float_value = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return float_value if math.isfinite(float_value) else None
 
 
 def _normalize_store(stored: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -169,29 +197,50 @@ def _build_statistics(
     running_sum = Decimal("0")
 
     for day_value in sorted(daily_history):
-        reading_day = date.fromisoformat(day_value)
-        running_sum += Decimal(daily_history[day_value])
+        try:
+            reading_day = date.fromisoformat(day_value)
+        except ValueError:
+            continue
+        decimal_text = _decimal_string(daily_history[day_value])
+        if decimal_text is None:
+            continue
+
+        daily_decimal = Decimal(decimal_text)
+        candidate_sum = running_sum + daily_decimal
+        daily_value = _finite_float(daily_decimal)
+        sum_value = _finite_float(candidate_sum)
+        if daily_value is None or sum_value is None:
+            continue
+
+        running_sum = candidate_sum
         if reading_day < earliest_changed:
             continue
 
-        cumulative_value = float(running_sum)
         statistics.append(
             {
                 "start": _statistics_timestamp(reading_day),
-                "state": cumulative_value,
-                "sum": cumulative_value,
+                "state": daily_value,
+                "sum": sum_value,
             }
         )
 
     return statistics
 
 
-def _metadata(account_id: str, sensor_type: str, unit: str) -> StatisticMetaData:
+def _metadata(
+    account_id: str,
+    sensor_type: str,
+    unit: str,
+    language: str = "en",
+) -> StatisticMetaData:
     """Build recorder metadata for one daily consumption type."""
+    language_code = language.replace("_", "-").partition("-")[0].casefold()
+    names = _STATISTIC_NAMES.get(language_code, _STATISTIC_NAMES["en"])
+    statistic_name = names.get(sensor_type, f"{sensor_type.title()} consumption")
     return {
         "mean_type": StatisticMeanType.NONE,
         "has_sum": True,
-        "name": f"ista EcoTrend {_STATISTIC_NAMES.get(sensor_type, sensor_type)} spotřeba",
+        "name": f"ista EcoTrend {statistic_name}",
         "source": DOMAIN,
         "statistic_id": statistic_id(account_id, sensor_type),
         "unit_class": _VOLUME_UNIT_CLASS if unit == _VOLUME_UNIT else None,
@@ -208,6 +257,7 @@ async def async_sync_czech_statistics(
     components = getattr(getattr(hass, "config", None), "components", ())
     if "recorder" not in components:
         return
+    language = str(getattr(hass.config, "language", "en"))
 
     store = Store(hass, _STORE_VERSION, _store_key(account_id))
     stored = await store.async_load()
@@ -221,7 +271,7 @@ async def async_sync_czech_statistics(
         if statistics:
             async_add_external_statistics(
                 hass,
-                _metadata(account_id, sensor_type, history["unit"]),
+                _metadata(account_id, sensor_type, history["unit"], language),
                 statistics,
             )
 

--- a/custom_components/ecotrend_ista/czech_statistics.py
+++ b/custom_components/ecotrend_ista/czech_statistics.py
@@ -90,6 +90,25 @@ def _finite_float(value: Decimal) -> float | None:
     return float_value if math.isfinite(float_value) else None
 
 
+def _normalize_daily_history(daily: Any) -> dict[str, str]:
+    """Normalize persisted daily values while discarding malformed entries."""
+    if not isinstance(daily, Mapping):
+        return {}
+
+    normalized: dict[str, str] = {}
+    for day_value, consumption in daily.items():
+        if not isinstance(day_value, str):
+            continue
+        try:
+            date.fromisoformat(day_value)
+        except ValueError:
+            continue
+        if (decimal_value := _decimal_string(consumption)) is not None:
+            normalized[day_value] = decimal_value
+
+    return normalized
+
+
 def _normalize_store(stored: Mapping[str, Any] | None) -> dict[str, Any]:
     """Normalize persisted data while discarding malformed values."""
     normalized: dict[str, Any] = {"types": {}}
@@ -106,24 +125,61 @@ def _normalize_store(stored: Mapping[str, Any] | None) -> dict[str, Any]:
 
         unit = stored_type.get("unit")
         daily = stored_type.get("daily")
-        normalized_daily: dict[str, str] = {}
-        if isinstance(daily, Mapping):
-            for day_value, consumption in daily.items():
-                if not isinstance(day_value, str):
-                    continue
-                try:
-                    date.fromisoformat(day_value)
-                except ValueError:
-                    continue
-                if (decimal_value := _decimal_string(consumption)) is not None:
-                    normalized_daily[day_value] = decimal_value
 
         normalized["types"][sensor_type] = {
             "unit": unit if isinstance(unit, str) else "",
-            "daily": normalized_daily,
+            "daily": _normalize_daily_history(daily),
         }
 
     return normalized
+
+
+def _parse_daily_reading(item: Any) -> tuple[str, date, str] | None:
+    """Parse one API daily reading or return None when it is malformed."""
+    if not isinstance(item, Mapping):
+        return None
+
+    day_value = item.get("date")
+    if not isinstance(day_value, str):
+        return None
+    try:
+        reading_day = date.fromisoformat(day_value)
+    except ValueError:
+        return None
+
+    value = _decimal_string(item.get("value"))
+    if value is None:
+        return None
+    return day_value, reading_day, value
+
+
+def _merge_aggregate_history(history: dict[str, Any], aggregate: Mapping[str, Any]) -> date | None:
+    """Merge one aggregate and return the earliest changed date."""
+    daily_history: dict[str, str] = history["daily"]
+    earliest_changed: date | None = None
+
+    unit = aggregate.get("unit")
+    if isinstance(unit, str) and unit != history["unit"]:
+        history["unit"] = unit
+        if daily_history:
+            earliest_changed = date.fromisoformat(min(daily_history))
+
+    daily = aggregate.get("daily")
+    if not isinstance(daily, list):
+        return earliest_changed
+
+    for item in daily:
+        reading = _parse_daily_reading(item)
+        if reading is None:
+            continue
+        day_value, reading_day, value = reading
+        if daily_history.get(day_value) == value:
+            continue
+
+        daily_history[day_value] = value
+        earliest_changed = min(earliest_changed, reading_day) if earliest_changed else reading_day
+
+    return earliest_changed
 
 
 def _merge_daily_history(
@@ -133,44 +189,15 @@ def _merge_daily_history(
     """Merge API values into stored history and return earliest changed dates."""
     merged = _normalize_store(stored)
     earliest_changed: dict[str, date] = {}
+    types = merged["types"]
 
     for sensor_type, aggregate in aggregates.items():
         if not isinstance(sensor_type, str) or not isinstance(aggregate, Mapping):
             continue
 
-        types = merged["types"]
         history = types.setdefault(sensor_type, {"unit": "", "daily": {}})
-        daily_history: dict[str, str] = history["daily"]
-
-        unit = aggregate.get("unit")
-        if isinstance(unit, str) and unit != history["unit"]:
-            history["unit"] = unit
-            if daily_history:
-                earliest_changed[sensor_type] = date.fromisoformat(min(daily_history))
-
-        daily = aggregate.get("daily")
-        if not isinstance(daily, list):
-            continue
-
-        for item in daily:
-            if not isinstance(item, Mapping):
-                continue
-            day_value = item.get("date")
-            if not isinstance(day_value, str):
-                continue
-            try:
-                reading_day = date.fromisoformat(day_value)
-            except ValueError:
-                continue
-            if (value := _decimal_string(item.get("value"))) is None:
-                continue
-
-            if daily_history.get(day_value) == value:
-                continue
-
-            daily_history[day_value] = value
-            changed = earliest_changed.get(sensor_type)
-            earliest_changed[sensor_type] = min(changed, reading_day) if changed else reading_day
+        if (changed_from := _merge_aggregate_history(history, aggregate)) is not None:
+            earliest_changed[sensor_type] = changed_from
 
     return merged, earliest_changed
 

--- a/custom_components/ecotrend_ista/diagnostics.py
+++ b/custom_components/ecotrend_ista/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for YouTube."""
+"""Diagnostics support for ista EcoTrend."""
 
 from __future__ import annotations
 
@@ -7,11 +7,47 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_URL, DOMAIN
 from .coordinator import IstaDataUpdateCoordinator
+
+
+def _czech_diagnostics(data: Any) -> dict[str, Any]:
+    """Return a privacy-safe summary of Czech account data."""
+    if not isinstance(data, dict):
+        return {"meter_count": 0, "meter_types": [], "aggregates": {}}
+
+    meters = data.get("meters")
+    meter_items = meters if isinstance(meters, list) else []
+    meter_types = sorted(
+        {str(meter["type"]) for meter in meter_items if isinstance(meter, dict) and meter.get("type") is not None}
+    )
+
+    aggregate_summary: dict[str, dict[str, Any]] = {}
+    aggregates = data.get("aggregates")
+    if isinstance(aggregates, dict):
+        for consumption_type, aggregate in aggregates.items():
+            if not isinstance(consumption_type, str) or not isinstance(aggregate, dict):
+                continue
+            daily = aggregate.get("daily")
+            monthly = aggregate.get("monthly")
+            aggregate_summary[consumption_type] = {
+                "unit": aggregate.get("unit"),
+                "daily_reading_count": len(daily) if isinstance(daily, list) else 0,
+                "monthly_reading_count": len(monthly) if isinstance(monthly, list) else 0,
+                "has_latest_daily_value": aggregate.get("daily_value") is not None,
+                "has_latest_monthly_value": aggregate.get("monthly_value") is not None,
+            }
+
+    return {
+        "meter_count": len(meter_items),
+        "meter_types": meter_types,
+        "aggregates": aggregate_summary,
+    }
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: IstaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if entry.options.get(CONF_URL) == "cz_url":
+        return _czech_diagnostics(coordinator.data)
     return coordinator.data

--- a/custom_components/ecotrend_ista/diagnostics.py
+++ b/custom_components/ecotrend_ista/diagnostics.py
@@ -11,6 +11,37 @@ from .const import CONF_URL, DOMAIN
 from .coordinator import IstaDataUpdateCoordinator
 
 
+def _meter_types(meter_items: list[Any]) -> list[str]:
+    """Return the distinct public meter types."""
+    return sorted({str(meter["type"]) for meter in meter_items if isinstance(meter, dict) and meter.get("type") is not None})
+
+
+def _summarize_aggregate(aggregate: dict[str, Any]) -> dict[str, Any]:
+    """Return non-sensitive metadata for one aggregate."""
+    daily = aggregate.get("daily")
+    monthly = aggregate.get("monthly")
+    return {
+        "unit": aggregate.get("unit"),
+        "daily_reading_count": len(daily) if isinstance(daily, list) else 0,
+        "monthly_reading_count": len(monthly) if isinstance(monthly, list) else 0,
+        "has_latest_daily_value": aggregate.get("daily_value") is not None,
+        "has_latest_monthly_value": aggregate.get("monthly_value") is not None,
+    }
+
+
+def _summarize_aggregates(aggregates: Any) -> dict[str, dict[str, Any]]:
+    """Return non-sensitive metadata for all valid aggregates."""
+    if not isinstance(aggregates, dict):
+        return {}
+
+    summary: dict[str, dict[str, Any]] = {}
+    for consumption_type, aggregate in aggregates.items():
+        if not isinstance(consumption_type, str) or not isinstance(aggregate, dict):
+            continue
+        summary[consumption_type] = _summarize_aggregate(aggregate)
+    return summary
+
+
 def _czech_diagnostics(data: Any) -> dict[str, Any]:
     """Return a privacy-safe summary of Czech account data."""
     if not isinstance(data, dict):
@@ -18,30 +49,11 @@ def _czech_diagnostics(data: Any) -> dict[str, Any]:
 
     meters = data.get("meters")
     meter_items = meters if isinstance(meters, list) else []
-    meter_types = sorted(
-        {str(meter["type"]) for meter in meter_items if isinstance(meter, dict) and meter.get("type") is not None}
-    )
-
-    aggregate_summary: dict[str, dict[str, Any]] = {}
-    aggregates = data.get("aggregates")
-    if isinstance(aggregates, dict):
-        for consumption_type, aggregate in aggregates.items():
-            if not isinstance(consumption_type, str) or not isinstance(aggregate, dict):
-                continue
-            daily = aggregate.get("daily")
-            monthly = aggregate.get("monthly")
-            aggregate_summary[consumption_type] = {
-                "unit": aggregate.get("unit"),
-                "daily_reading_count": len(daily) if isinstance(daily, list) else 0,
-                "monthly_reading_count": len(monthly) if isinstance(monthly, list) else 0,
-                "has_latest_daily_value": aggregate.get("daily_value") is not None,
-                "has_latest_monthly_value": aggregate.get("monthly_value") is not None,
-            }
 
     return {
         "meter_count": len(meter_items),
-        "meter_types": meter_types,
-        "aggregates": aggregate_summary,
+        "meter_types": _meter_types(meter_items),
+        "aggregates": _summarize_aggregates(data.get("aggregates")),
     }
 
 

--- a/custom_components/ecotrend_ista/manifest.json
+++ b/custom_components/ecotrend_ista/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "ecotrend_ista",
     "name": "ista EcoTrend",
+    "after_dependencies": ["recorder"],
     "codeowners": [
         "@Ludy87"
     ],
@@ -16,5 +17,5 @@
         "pyotp==2.8.0",
         "marshmallow-enum==1.5.1"
     ],
-    "version": "v3.4.0"
+    "version": "v3.5.0"
 }

--- a/custom_components/ecotrend_ista/sensor.py
+++ b/custom_components/ecotrend_ista/sensor.py
@@ -7,9 +7,6 @@ import datetime
 import logging
 from typing import Any, cast
 
-from pyecotrend_ista.helper_object_de import CustomRaw
-from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
-
 from homeassistant.components.sensor import RestoreSensor, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -18,6 +15,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pyecotrend_ista.helper_object_de import CustomRaw
+from pyecotrend_ista.pyecotrend_ista import PyEcotrendIsta
 
 from .const import (
     CONF_TYPE_HEATING_CUSTOM,
@@ -30,6 +29,7 @@ from .const import (
 )
 from .const_schema import URL_SELECTORS
 from .coordinator import IstaDataUpdateCoordinator
+from .czech_sensor import create_czech_sensor_entities
 from .entity import SENSOR_TYPES, EcotrendSensorEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,6 +132,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up the ista EcoTrend Version 3 sensors from the config entry."""
     coordinator: IstaDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    if config_entry.options.get(CONF_URL) == "cz_url":
+        async_add_entities(create_czech_sensor_entities(coordinator))
+        return
 
     controller = coordinator.controller
 

--- a/custom_components/ecotrend_ista/strings.json
+++ b/custom_components/ecotrend_ista/strings.json
@@ -9,9 +9,10 @@
       "default": "[%key:common::config_flow::create_entry::default%]"
     },
     "error": {
-      "auth_inval": "[%key:common::config_flow::error::auth_inval%]",
+      "auth_inval": "Login failed. Incorrect email address or username, password, or login URL.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_email": "[%key:common::config_flow::error::no_email%]",
+      "no_email": "Enter a valid email address or username",
+      "not_allowed": "The selected URL is not supported",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
@@ -19,26 +20,73 @@
       "german": {
         "data": {
           "URL": "[%key:common::config_flow::data::URL%]",
-          "email": "[%key:common::config_flow::data::email%]",
+          "email": "Email address or username",
           "mfa_code": "[%key:common::config_flow::data::mfa_code%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "update_interval": "Update interval (h)"
         },
         "description": "[%key:common::config_flow::german::description%]",
         "title": "[%key:common::config_flow::german::title%]"
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "czech_heating_meter": {
+        "name": "Heating meter reading – {detail}",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_meter_native_unit": {
+        "name": "Heating meter reading – {detail}"
+      },
+      "czech_warm_water_meter": {
+        "name": "Hot water meter reading – {detail}"
+      },
+      "czech_cold_water_meter": {
+        "name": "Cold water meter reading – {detail}"
+      },
+      "czech_heating_daily": {
+        "name": "Heating – latest day",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_daily_native_unit": {
+        "name": "Heating – latest day"
+      },
+      "czech_heating_monthly": {
+        "name": "Monthly heating consumption",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_monthly_native_unit": {
+        "name": "Monthly heating consumption"
+      },
+      "czech_warm_water_daily": {
+        "name": "Hot water – latest day"
+      },
+      "czech_warm_water_monthly": {
+        "name": "Monthly hot water consumption"
+      },
+      "czech_cold_water_daily": {
+        "name": "Cold water – latest day"
+      },
+      "czech_cold_water_monthly": {
+        "name": "Monthly cold water consumption"
+      },
+      "czech_data_through": {
+        "name": "Data available through"
+      }
+    }
+  },
   "options": {
     "error": {
-      "not_allowed": "Die gewählte URL ist nicht erlaubt"
+      "not_allowed": "The selected URL is not supported"
     },
     "step": {
       "init": {
         "data": {
-          "URL": "Login-Url",
-          "update_interval": "Update Interval (h)"
+          "URL": "Login URL",
+          "update_interval": "Update interval (h)"
         },
-        "title": "Einstellungen für ista EcoTrend"
+        "title": "Settings for ista EcoTrend"
       }
     }
   }

--- a/custom_components/ecotrend_ista/translations/cs.json
+++ b/custom_components/ecotrend_ista/translations/cs.json
@@ -1,0 +1,92 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Integrace již byla nakonfigurována",
+      "single_instance_allowed": "Integrace je již nakonfigurována. Je povolena pouze jedna konfigurace."
+    },
+    "create_entry": {
+      "default": "Integrace ista EcoTrend byla vytvořena."
+    },
+    "error": {
+      "auth_inval": "Přihlášení se nezdařilo. E-mail, uživatelské jméno, heslo nebo přihlašovací URL nejsou správné.",
+      "cannot_connect": "Připojení se nezdařilo",
+      "no_email": "Zadejte platný e-mail nebo uživatelské jméno",
+      "not_allowed": "Vybraná URL není podporována",
+      "timeout_connect": "Při navazování spojení vypršel časový limit",
+      "unknown": "Došlo k neočekávané chybě"
+    },
+    "step": {
+      "german": {
+        "data": {
+          "URL": "Přihlašovací URL",
+          "email": "E-mail nebo uživatelské jméno",
+          "mfa_code": "Kód dvoufázového ověření",
+          "password": "Heslo",
+          "update_interval": "Interval aktualizace (h)"
+        },
+        "description": "Přihlášení k účtu",
+        "title": "Nastavit ista EcoTrend"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "czech_heating_meter": {
+        "name": "Stav měřidla topení – {detail}",
+        "unit_of_measurement": "jednotek"
+      },
+      "czech_heating_meter_native_unit": {
+        "name": "Stav měřidla topení – {detail}"
+      },
+      "czech_warm_water_meter": {
+        "name": "Stav měřidla teplé vody – {detail}"
+      },
+      "czech_cold_water_meter": {
+        "name": "Stav měřidla studené vody – {detail}"
+      },
+      "czech_heating_daily": {
+        "name": "Vytápění – poslední den",
+        "unit_of_measurement": "jednotek"
+      },
+      "czech_heating_daily_native_unit": {
+        "name": "Vytápění – poslední den"
+      },
+      "czech_heating_monthly": {
+        "name": "Měsíční spotřeba vytápění",
+        "unit_of_measurement": "jednotek"
+      },
+      "czech_heating_monthly_native_unit": {
+        "name": "Měsíční spotřeba vytápění"
+      },
+      "czech_warm_water_daily": {
+        "name": "Teplá voda – poslední den"
+      },
+      "czech_warm_water_monthly": {
+        "name": "Měsíční spotřeba teplé vody"
+      },
+      "czech_cold_water_daily": {
+        "name": "Studená voda – poslední den"
+      },
+      "czech_cold_water_monthly": {
+        "name": "Měsíční spotřeba studené vody"
+      },
+      "czech_data_through": {
+        "name": "Data dostupná do"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "not_allowed": "Vybraná URL není podporována"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "URL": "Přihlašovací URL",
+          "update_interval": "Interval aktualizace (h)"
+        },
+        "title": "Nastavení ista EcoTrend"
+      }
+    }
+  }
+}

--- a/custom_components/ecotrend_ista/translations/en.json
+++ b/custom_components/ecotrend_ista/translations/en.json
@@ -8,10 +8,10 @@
       "default": "ista EcoTrend integration has been created!"
     },
     "error": {
-      "auth_inval": "Login failed. Incorrect email address, password, or login URL.",
+      "auth_inval": "Login failed. Incorrect email address or username, password, or login URL.",
       "cannot_connect": "Connection failed",
-      "no_email": "Email Invalid",
-      "not_allowed": "The selected URL is not yet supported",
+      "no_email": "Enter a valid email address or username",
+      "not_allowed": "The selected URL is not supported",
       "timeout_connect": "Timeout establishing connection",
       "unknown": "Unexpected error"
     },
@@ -19,25 +19,71 @@
       "german": {
         "data": {
           "URL": "Login URL",
-          "email": "Email address",
+          "email": "Email address or username",
           "mfa_code": "Two-factor authentication",
           "password": "Password",
-          "update_interval": "Update Interval (h)"
+          "update_interval": "Update interval (h)"
         },
         "description": "Account authentication",
         "title": "Set up ista EcoTrend"
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "czech_heating_meter": {
+        "name": "Heating meter reading – {detail}",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_meter_native_unit": {
+        "name": "Heating meter reading – {detail}"
+      },
+      "czech_warm_water_meter": {
+        "name": "Hot water meter reading – {detail}"
+      },
+      "czech_cold_water_meter": {
+        "name": "Cold water meter reading – {detail}"
+      },
+      "czech_heating_daily": {
+        "name": "Heating – latest day",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_daily_native_unit": {
+        "name": "Heating – latest day"
+      },
+      "czech_heating_monthly": {
+        "name": "Monthly heating consumption",
+        "unit_of_measurement": "units"
+      },
+      "czech_heating_monthly_native_unit": {
+        "name": "Monthly heating consumption"
+      },
+      "czech_warm_water_daily": {
+        "name": "Hot water – latest day"
+      },
+      "czech_warm_water_monthly": {
+        "name": "Monthly hot water consumption"
+      },
+      "czech_cold_water_daily": {
+        "name": "Cold water – latest day"
+      },
+      "czech_cold_water_monthly": {
+        "name": "Monthly cold water consumption"
+      },
+      "czech_data_through": {
+        "name": "Data available through"
+      }
+    }
+  },
   "options": {
     "error": {
-      "not_allowed": "The selected URL is not yet supported"
+      "not_allowed": "The selected URL is not supported"
     },
     "step": {
       "init": {
         "data": {
           "URL": "Login URL",
-          "update_interval": "Update Interval (h)"
+          "update_interval": "Update interval (h)"
         },
         "title": "Settings for ista EcoTrend"
       }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "ista EcoTrend",
     "zip_release": true,
-    "country": "DE",
+    "country": ["CZ", "DE"],
     "render_readme": true,
     "homeassistant": "2025.10.1",
     "hacs": "2.0.5",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC
-from enum import Enum, IntEnum, StrEnum
+from enum import IntEnum, StrEnum
 from pathlib import Path
 import sys
 import types
@@ -104,7 +104,7 @@ const.CONF_PASSWORD = "password"
 const.CONF_SCAN_INTERVAL = "scan_interval"
 
 
-class Platform(str, Enum):
+class Platform(StrEnum):
     """Mimic Home Assistant's Platform enum with the attributes required by the integration."""
 
     SENSOR = "sensor"
@@ -132,6 +132,7 @@ sensor_component = _ensure_module("homeassistant.components.sensor")
 class SensorDeviceClass(StrEnum):
     """Sensor device classes used by the integration."""
 
+    DATE = "date"
     WATER = "water"
 
 
@@ -182,6 +183,7 @@ class RegistryEntry:
     """Simplified registry entry used during migration tests."""
 
     def __init__(self, *, entity_id: str = "", unique_id: str = "", domain: str = "sensor", platform: str = "sensor") -> None:
+        """Store registry entry fields used by migration tests."""
         self.entity_id = entity_id
         self.unique_id = unique_id
         self.domain = domain
@@ -196,10 +198,12 @@ class _EntityRegistry:
 
 
 async def async_migrate_entries(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover - behaviour not exercised
+    """Stand in for Home Assistant entity registry migration."""
     return None
 
 
 def async_get(_hass: Any) -> _EntityRegistry:
+    """Return the shared entity registry stub."""
     return _EntityRegistry()
 
 
@@ -218,6 +222,7 @@ class NumberSelectorConfig:
     """Store configuration for a number selector."""
 
     def __init__(self, **kwargs: Any) -> None:
+        """Store selector configuration."""
         self.config = kwargs
 
 
@@ -225,6 +230,7 @@ class NumberSelector:
     """Stub for the Home Assistant NumberSelector."""
 
     def __init__(self, _config: NumberSelectorConfig) -> None:
+        """Store the number selector configuration."""
         self.config = _config
 
 
@@ -238,6 +244,7 @@ class SelectOptionDict(dict):
     """Simple dictionary implementation matching Home Assistant's structure."""
 
     def __init__(self, *, value: str, label: str) -> None:
+        """Store a select option value and label."""
         super().__init__(value=value, label=label)
 
 
@@ -245,6 +252,7 @@ class SelectSelectorConfig:
     """Configuration for a select selector."""
 
     def __init__(self, **kwargs: Any) -> None:
+        """Store selector configuration."""
         self.config = kwargs
 
 
@@ -252,6 +260,7 @@ class SelectSelector:
     """Stub for the SelectSelector."""
 
     def __init__(self, _config: SelectSelectorConfig) -> None:
+        """Store the select selector configuration."""
         self.config = _config
 
 
@@ -267,6 +276,7 @@ class TextSelectorConfig:
     """Configuration container for text selectors."""
 
     def __init__(self, **kwargs: Any) -> None:
+        """Store selector configuration."""
         self.config = kwargs
 
 
@@ -274,6 +284,7 @@ class TextSelector:
     """Stub for the TextSelector."""
 
     def __init__(self, _config: TextSelectorConfig) -> None:
+        """Store the text selector configuration."""
         self.config = _config
 
 
@@ -296,6 +307,7 @@ class DataUpdateCoordinator:
     """Simplified DataUpdateCoordinator stub."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Store coordinator arguments used by tests."""
         self.hass = kwargs.get("hass")
         self.logger = kwargs.get("logger")
         self.name = kwargs.get("name")
@@ -307,6 +319,10 @@ class DataUpdateCoordinator:
         """Store updated data."""
 
         self.data = data
+
+
+class UpdateFailed(Exception):
+    """Represent a failed coordinator update."""
 
 
 class CoordinatorEntity:
@@ -324,6 +340,7 @@ class CoordinatorEntity:
 
 update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
 update_coordinator.CoordinatorEntity = CoordinatorEntity
+update_coordinator.UpdateFailed = UpdateFailed
 helpers.update_coordinator = update_coordinator
 
 storage = _ensure_module("homeassistant.helpers.storage")
@@ -412,13 +429,16 @@ class CustomRaw:
     """Lightweight stand-in for the CustomRaw helper object."""
 
     def __init__(self, data: dict[str, Any]) -> None:
+        """Store the serialized consumption data."""
         self._data = data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CustomRaw:
+        """Build a stub instance from serialized data."""
         return cls(data)
 
     def to_dict(self) -> dict[str, Any]:
+        """Return the serialized consumption data."""
         return self._data
 
 
@@ -431,18 +451,23 @@ class PyEcotrendIsta:  # pragma: no cover - replaced by tests when required
     """Minimal stub for the external API client."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Store client constructor arguments."""
         self.kwargs = kwargs
 
     def login(self) -> None:  # pragma: no cover - replaced by monkeypatch in tests
+        """Represent the external client login call."""
         raise NotImplementedError
 
     def get_support_code(self) -> str:  # pragma: no cover - default helper
+        """Return a deterministic support code."""
         return "SC"
 
     def getUUIDs(self) -> list[str]:  # pragma: no cover - not used
+        """Return no consumption unit identifiers by default."""
         return []
 
     def consum_raw(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover - not used
+        """Return an empty raw consumption payload."""
         return {}
 
 
@@ -473,22 +498,27 @@ def Email():
 
 
 def Schema(schema: Any, **_kwargs: Any) -> Any:  # pragma: no cover - behaviour not required for tests
+    """Return the supplied schema unchanged."""
     return schema
 
 
 def Required(key: Any, default: Any | None = None) -> Any:  # pragma: no cover - helper for schema construction
+    """Return a required schema key."""
     return key
 
 
 def Optional(key: Any, default: Any | None = None) -> Any:  # pragma: no cover - helper for schema construction
+    """Return an optional schema key."""
     return key
 
 
 def Remove(key: Any) -> Any:  # pragma: no cover - helper for schema construction
+    """Return a removable schema key."""
     return key
 
 
 def Any(*values: Any) -> Any:  # pragma: no cover - helper for schema construction
+    """Return accepted schema values."""
     return values
 
 
@@ -521,6 +551,7 @@ class Session:  # pragma: no cover - only used for instantiation
     """Minimal requests Session stub."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Store session constructor arguments."""
         self.args = args
         self.kwargs = kwargs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,11 +353,11 @@ class Store:  # pragma: no cover - replaced by statistics tests
         """Initialize empty in-memory storage."""
         self.data = None
 
-    async def async_load(self):
+    async def async_load(self):  # NOSONAR - Stub mirrors Home Assistant's async Store API.
         """Return no persisted data by default."""
         return self.data
 
-    async def async_save(self, data: Any) -> None:
+    async def async_save(self, data: Any) -> None:  # NOSONAR - Stub mirrors Home Assistant's async Store API.
         """Store data in memory."""
         self.data = data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import UTC
+from enum import Enum, IntEnum, StrEnum
+from pathlib import Path
 import sys
 import types
-from enum import Enum
-from pathlib import Path
 from typing import Any
 
 
@@ -110,10 +112,70 @@ class Platform(str, Enum):
 
 const.Platform = Platform
 
+
+class UnitOfVolume:
+    """Volume units required by Czech water sensors."""
+
+    CUBIC_METERS = "m³"
+
+
+const.UnitOfVolume = UnitOfVolume
+
 helpers = _ensure_module("homeassistant.helpers")
 selector = _ensure_module("homeassistant.helpers.selector")
 entity_registry = _ensure_module("homeassistant.helpers.entity_registry")
 helpers.entity_registry = entity_registry
+
+sensor_component = _ensure_module("homeassistant.components.sensor")
+
+
+class SensorDeviceClass(StrEnum):
+    """Sensor device classes used by the integration."""
+
+    WATER = "water"
+
+
+class SensorStateClass(StrEnum):
+    """Sensor state classes used by the integration."""
+
+    TOTAL = "total"
+    TOTAL_INCREASING = "total_increasing"
+
+
+@dataclass
+class SensorEntityDescription:
+    """Minimal sensor entity description."""
+
+    key: str
+    native_unit_of_measurement: str | None = None
+    device_class: SensorDeviceClass | None = None
+    state_class: SensorStateClass | None = None
+    entity_category: Any = None
+    icon: str | None = None
+
+
+class SensorEntity:
+    """Minimal Home Assistant sensor entity."""
+
+
+sensor_component.SensorDeviceClass = SensorDeviceClass
+sensor_component.SensorEntity = SensorEntity
+sensor_component.SensorEntityDescription = SensorEntityDescription
+sensor_component.SensorStateClass = SensorStateClass
+
+device_registry = _ensure_module("homeassistant.helpers.device_registry")
+
+
+class DeviceInfo(dict):
+    """Dictionary-shaped device metadata used by entity tests."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Store device metadata."""
+        super().__init__(**kwargs)
+
+
+device_registry.DeviceInfo = DeviceInfo
+helpers.device_registry = device_registry
 
 
 class RegistryEntry:
@@ -247,11 +309,48 @@ class DataUpdateCoordinator:
         self.data = data
 
 
+class CoordinatorEntity:
+    """Minimal coordinator-backed entity base."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator) -> None:
+        """Store the coordinator reference."""
+        self.coordinator = coordinator
+
+    @classmethod
+    def __class_getitem__(cls, _item: Any):
+        """Allow generic coordinator entity annotations."""
+        return cls
+
+
 update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
+update_coordinator.CoordinatorEntity = CoordinatorEntity
 helpers.update_coordinator = update_coordinator
+
+storage = _ensure_module("homeassistant.helpers.storage")
+
+
+class Store:  # pragma: no cover - replaced by statistics tests
+    """Minimal Home Assistant storage placeholder."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        """Initialize empty in-memory storage."""
+        self.data = None
+
+    async def async_load(self):
+        """Return no persisted data by default."""
+        return self.data
+
+    async def async_save(self, data: Any) -> None:
+        """Store data in memory."""
+        self.data = data
+
+
+storage.Store = Store
+helpers.storage = storage
 
 helpers_typing = _ensure_module("homeassistant.helpers.typing")
 helpers_typing.ConfigType = dict[str, Any]
+helpers_typing.StateType = Any
 
 data_entry_flow = _ensure_module("homeassistant.data_entry_flow")
 data_entry_flow.FlowResult = dict
@@ -263,6 +362,35 @@ helpers.update_coordinator = update_coordinator
 
 _data_entry_flow = _ensure_module("homeassistant.data_entry_flow")
 _data_entry_flow.FlowResult = dict
+
+recorder_models = _ensure_module("homeassistant.components.recorder.models")
+
+
+class StatisticMeanType(IntEnum):
+    """Mimic Home Assistant's statistic mean type."""
+
+    NONE = 0
+    ARITHMETIC = 1
+    CIRCULAR = 2
+
+
+recorder_models.StatisticData = dict
+recorder_models.StatisticMeanType = StatisticMeanType
+recorder_models.StatisticMetaData = dict
+
+recorder_statistics = _ensure_module("homeassistant.components.recorder.statistics")
+
+
+def async_add_external_statistics(*_args: Any, **_kwargs: Any) -> None:
+    """Placeholder recorder import callback."""
+
+
+recorder_statistics.async_add_external_statistics = async_add_external_statistics
+
+homeassistant_util = _ensure_module("homeassistant.util")
+dt_util = _ensure_module("homeassistant.util.dt")
+dt_util.DEFAULT_TIME_ZONE = UTC
+homeassistant_util.dt = dt_util
 
 
 # Stub external library used by the integration.
@@ -287,7 +415,7 @@ class CustomRaw:
         self._data = data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "CustomRaw":
+    def from_dict(cls, data: dict[str, Any]) -> CustomRaw:
         return cls(data)
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,16 +6,16 @@ import asyncio
 from types import MappingProxyType
 from typing import Any
 
-import pytest
-
 from custom_components.ecotrend_ista import config_flow
 from custom_components.ecotrend_ista.config_flow import NotSupportedURL, validate_input, validate_options_input
+import pytest
 
 
 class DummyHass:
     """Lightweight HomeAssistant stand-in for tests."""
 
     async def async_add_executor_job(self, func, *args: Any, **kwargs: Any) -> Any:
+        """Run a synchronous callable immediately."""
         return func(*args, **kwargs)
 
 
@@ -82,10 +82,48 @@ def test_validate_input_propagates_login_error(monkeypatch: pytest.MonkeyPatch, 
         asyncio.run(validate_input(hass, valid_user_input))
 
 
+def test_validate_input_accepts_czech_username(monkeypatch: pytest.MonkeyPatch, valid_user_input: dict[str, Any]) -> None:
+    """The Czech backend accepts account names that are not email addresses."""
+
+    class DummyAccount:
+        def login(self) -> None:
+            return None
+
+        def get_support_code(self) -> str:
+            return "cz-123"
+
+    czech_input = dict(valid_user_input, email="tenant-login", URL="cz_url")
+    monkeypatch.setattr(config_flow, "login_account", lambda *args, **kwargs: DummyAccount())
+
+    result = asyncio.run(validate_input(DummyHass(), czech_input))
+
+    assert result == {"title": "Ista cz-123 "}
+
+
+def test_login_account_uses_czech_client(monkeypatch: pytest.MonkeyPatch, valid_user_input: dict[str, Any]) -> None:
+    """The selected URL must control which client implementation is created."""
+
+    captured: dict[str, Any] = {}
+
+    class DummyCzechClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(config_flow, "CzechPyEcotrendIsta", DummyCzechClient)
+    czech_input = dict(valid_user_input, email="tenant-login", URL="cz_url")
+
+    account = config_flow.login_account(DummyHass(), czech_input)
+
+    assert isinstance(account, DummyCzechClient)
+    assert captured["email"] == "tenant-login"
+    assert captured["password"] == "secret"
+
+
 def test_validate_options_input_returns_no_errors(valid_user_input: dict[str, Any]) -> None:
     """The option validation should accept the supported URL."""
 
     assert validate_options_input({"URL": "de_url"}) == {}
+    assert validate_options_input({"URL": "cz_url"}) == {}
 
 
 def test_validate_options_input_rejects_invalid_url() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -130,3 +130,13 @@ def test_validate_options_input_rejects_invalid_url() -> None:
     """An unsupported URL produces an error message."""
 
     assert validate_options_input({"URL": "other"}) == {"base": "not_allowed"}
+
+
+def test_options_flow_preserves_portal_without_offering_a_backend_switch() -> None:
+    """Changing the refresh interval must preserve the validated login portal."""
+    flow = config_flow.IstaOptionsFlowHandler()
+    flow.options = {"URL": "cz_url", "update_interval": 24}
+
+    result = asyncio.run(flow.async_step_init({"update_interval": 12}))
+
+    assert result["data"] == {"URL": "cz_url", "update_interval": 12}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
-import asyncio
 from pathlib import Path
 from typing import Any
 
-
-from custom_components.ecotrend_ista.coordinator import create_directory_file
+from custom_components.ecotrend_ista import coordinator
+from custom_components.ecotrend_ista.coordinator import IstaDataUpdateCoordinator, create_directory_file
 
 
 class DummyConfig:
     """Provide a minimal config object with a path helper."""
 
     def __init__(self, base: str) -> None:
+        """Store the temporary base path."""
         self._base = base
 
     def path(self, *paths: str) -> str:
+        """Build a path relative to the temporary base."""
         return os.path.join(self._base, *paths)
 
 
@@ -26,9 +28,11 @@ class DummyHass:
     """Simplified hass object for coordinator tests."""
 
     def __init__(self, base: str) -> None:
+        """Initialize the fake Home Assistant configuration."""
         self.config = DummyConfig(base)
 
     async def async_add_executor_job(self, func, *args: Any, **kwargs: Any) -> Any:
+        """Run a synchronous callable immediately."""
         return func(*args, **kwargs)
 
 
@@ -36,9 +40,11 @@ class DummyRaw:
     """Minimal replacement for the CustomRaw object."""
 
     def __init__(self, payload: dict[str, Any]) -> None:
+        """Store the payload returned by ``to_dict``."""
         self._payload = payload
 
     def to_dict(self) -> dict[str, Any]:
+        """Return the stored payload."""
         return self._payload
 
 
@@ -58,3 +64,159 @@ def test_create_directory_file_writes_expected_json(tmp_path: Path) -> None:
         data = json.load(file)
 
     assert data == payload
+
+
+def test_set_controller_passes_selected_backend(monkeypatch) -> None:
+    """The coordinator must not discard the URL stored in config-entry options."""
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {"email": "tenant-login", "password": "secret", "mfa_code": ""}
+        options = {"URL": "cz_url", "update_interval": 24}
+
+    class CoordinatorHass:
+        pass
+
+    captured: dict[str, Any] = {}
+    expected_controller = object()
+
+    def fake_login_account(_hass, data, demo=False):
+        captured.update(data)
+        assert demo is False
+        return expected_controller
+
+    monkeypatch.setattr(coordinator, "login_account", fake_login_account)
+    data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
+
+    data_coordinator.set_controller()
+
+    assert data_coordinator.controller is expected_controller
+    assert captured["URL"] == "cz_url"
+
+
+def test_czech_update_uses_home_assistant_payload_and_syncs_statistics(monkeypatch) -> None:
+    """Czech updates should avoid the legacy German consumption parser."""
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {"email": "tenant-login", "password": "secret", "mfa_code": ""}
+        options = {"URL": "cz_url", "update_interval": 24}
+
+    class CoordinatorHass:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:
+            return func(*args)
+
+    payload = {
+        "meters": [{"id": "meter-1", "type": "heating", "value": "10"}],
+        "aggregates": {"heating": {"unit": "díl", "daily": []}},
+    }
+
+    class CzechController:
+        def __init__(self) -> None:
+            self.home_data_calls = 0
+
+        def get_home_assistant_data(self) -> dict[str, Any]:
+            self.home_data_calls += 1
+            return payload
+
+        def get_support_code(self) -> str:
+            return "cz-account"
+
+        def consum_raw(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("The Czech path must not use consum_raw")
+
+    controller_instance = CzechController()
+    data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
+
+    async def fake_init() -> None:
+        data_coordinator.controller = controller_instance
+
+    synced: dict[str, Any] = {}
+
+    async def fake_sync(_hass, account_id: str, aggregates: dict[str, Any]) -> None:
+        synced["account_id"] = account_id
+        synced["aggregates"] = aggregates
+
+    monkeypatch.setattr(data_coordinator, "init", fake_init)
+    monkeypatch.setattr(coordinator, "async_sync_czech_statistics", fake_sync)
+
+    result = asyncio.run(data_coordinator._async_update_data())
+
+    assert result == payload
+    assert data_coordinator.czech_data == payload
+    assert controller_instance.home_data_calls == 1
+    assert synced == {
+        "account_id": "cz-account",
+        "aggregates": payload["aggregates"],
+    }
+
+
+def test_german_update_keeps_legacy_consumption_path(monkeypatch, tmp_path: Path) -> None:
+    """The Czech branch must not change the existing German update behavior."""
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {"email": "user@example.com", "password": "secret", "mfa_code": ""}
+        options = {"URL": "de_url", "update_interval": 24}
+
+    hass = DummyHass(str(tmp_path))
+    data_coordinator = IstaDataUpdateCoordinator(hass, DummyEntry())
+
+    class GermanController:
+        def get_uuids(self) -> list[str]:
+            return ["unit-1"]
+
+        def consum_raw(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"last_value": {"heating": 12}}
+
+        def get_support_code(self) -> str:
+            return "support"
+
+    async def fake_init() -> None:
+        data_coordinator.controller = GermanController()
+
+    monkeypatch.setattr(data_coordinator, "init", fake_init)
+
+    result = asyncio.run(data_coordinator._async_update_data())
+
+    assert result is not None
+    assert result["unit-1"].to_dict() == {"last_value": {"heating": 12}}
+    assert data_coordinator.czech_data is None
+
+
+def test_czech_first_refresh_reuses_setup_login(monkeypatch) -> None:
+    """The first refresh should not immediately repeat a successful Czech login."""
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {"email": "tenant-login", "password": "secret", "mfa_code": ""}
+        options = {"URL": "cz_url", "update_interval": 24}
+
+    class CoordinatorHass:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:
+            return func(*args)
+
+    class LoggedInController:
+        access_token = "token"
+
+        def get_home_assistant_data(self) -> dict[str, Any]:
+            return {"meters": [], "aggregates": {}}
+
+        def get_support_code(self) -> str:
+            return "cz-account"
+
+    data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
+    data_coordinator.controller = LoggedInController()
+
+    async def unexpected_init() -> None:
+        raise AssertionError("The initial Czech login should be reused")
+
+    async def fake_sync(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(data_coordinator, "init", unexpected_init)
+    monkeypatch.setattr(coordinator, "async_sync_czech_statistics", fake_sync)
+
+    result = asyncio.run(data_coordinator._async_update_data())
+
+    assert result == {"meters": [], "aggregates": {}}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from custom_components.ecotrend_ista import coordinator
 from custom_components.ecotrend_ista.coordinator import IstaDataUpdateCoordinator, create_directory_file
+import pytest
+import requests
 
 
 class DummyConfig:
@@ -220,3 +222,28 @@ def test_czech_first_refresh_reuses_setup_login(monkeypatch) -> None:
     result = asyncio.run(data_coordinator._async_update_data())
 
     assert result == {"meters": [], "aggregates": {}}
+
+
+def test_timeout_marks_coordinator_refresh_as_failed() -> None:
+    """A timeout must trigger a retry instead of accepting empty first-refresh data."""
+
+    class DummyEntry:
+        entry_id = "entry"
+        data = {"email": "tenant-login", "password": "secret", "mfa_code": ""}
+        options = {"URL": "cz_url", "update_interval": 24}
+
+    class CoordinatorHass:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:
+            return func(*args)
+
+    class TimedOutController:
+        access_token = "token"
+
+        def get_home_assistant_data(self) -> dict[str, Any]:
+            raise requests.Timeout("slow response")
+
+    data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
+    data_coordinator.controller = TimedOutController()
+
+    with pytest.raises(coordinator.UpdateFailed):
+        asyncio.run(data_coordinator._async_update_data())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -105,7 +105,7 @@ def test_czech_update_uses_home_assistant_payload_and_syncs_statistics(monkeypat
         options = {"URL": "cz_url", "update_interval": 24}
 
     class CoordinatorHass:
-        async def async_add_executor_job(self, func, *args: Any) -> Any:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:  # NOSONAR - Implements an awaited test API.
             return func(*args)
 
     payload = {
@@ -130,12 +130,14 @@ def test_czech_update_uses_home_assistant_payload_and_syncs_statistics(monkeypat
     controller_instance = CzechController()
     data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
 
-    async def fake_init() -> None:
+    async def fake_init() -> None:  # NOSONAR - Replaces an awaited coordinator method.
         data_coordinator.controller = controller_instance
 
     synced: dict[str, Any] = {}
 
-    async def fake_sync(_hass, account_id: str, aggregates: dict[str, Any]) -> None:
+    async def fake_sync(  # NOSONAR - Replaces an awaited statistics hook.
+        _hass, account_id: str, aggregates: dict[str, Any]
+    ) -> None:
         synced["account_id"] = account_id
         synced["aggregates"] = aggregates
 
@@ -174,7 +176,7 @@ def test_german_update_keeps_legacy_consumption_path(monkeypatch, tmp_path: Path
         def get_support_code(self) -> str:
             return "support"
 
-    async def fake_init() -> None:
+    async def fake_init() -> None:  # NOSONAR - Replaces an awaited coordinator method.
         data_coordinator.controller = GermanController()
 
     monkeypatch.setattr(data_coordinator, "init", fake_init)
@@ -195,7 +197,7 @@ def test_czech_first_refresh_reuses_setup_login(monkeypatch) -> None:
         options = {"URL": "cz_url", "update_interval": 24}
 
     class CoordinatorHass:
-        async def async_add_executor_job(self, func, *args: Any) -> Any:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:  # NOSONAR - Implements an awaited test API.
             return func(*args)
 
     class LoggedInController:
@@ -213,7 +215,7 @@ def test_czech_first_refresh_reuses_setup_login(monkeypatch) -> None:
     async def unexpected_init() -> None:
         raise AssertionError("The initial Czech login should be reused")
 
-    async def fake_sync(*_args: Any, **_kwargs: Any) -> None:
+    async def fake_sync(*_args: Any, **_kwargs: Any) -> None:  # NOSONAR - Replaces an awaited statistics hook.
         return None
 
     monkeypatch.setattr(data_coordinator, "init", unexpected_init)
@@ -233,7 +235,7 @@ def test_timeout_marks_coordinator_refresh_as_failed() -> None:
         options = {"URL": "cz_url", "update_interval": 24}
 
     class CoordinatorHass:
-        async def async_add_executor_job(self, func, *args: Any) -> Any:
+        async def async_add_executor_job(self, func, *args: Any) -> Any:  # NOSONAR - Implements an awaited test API.
             return func(*args)
 
     class TimedOutController:
@@ -245,5 +247,7 @@ def test_timeout_marks_coordinator_refresh_as_failed() -> None:
     data_coordinator = IstaDataUpdateCoordinator(CoordinatorHass(), DummyEntry())
     data_coordinator.controller = TimedOutController()
 
+    update = data_coordinator._async_update_data()
+
     with pytest.raises(coordinator.UpdateFailed):
-        asyncio.run(data_coordinator._async_update_data())
+        asyncio.run(update)

--- a/tests/test_czech_client.py
+++ b/tests/test_czech_client.py
@@ -1,0 +1,338 @@
+"""Tests for the Czech/Nordic ista client adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from custom_components.ecotrend_ista.czech_client import (
+    CZECH_METERS_URL,
+    CZECH_READING_URL,
+    CZECH_TOKEN_URL,
+    CzechPyEcotrendIsta,
+    _login_proofs,
+)
+
+
+class FakeResponse:
+    """Minimal requests response used by the adapter tests."""
+
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        """Store a JSON payload and HTTP status."""
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        """Return the configured JSON body."""
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        """Raise when the configured status represents an error."""
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    """Return deterministic token, meter and reading responses."""
+
+    def __init__(self) -> None:
+        """Initialize request capture collections."""
+        self.headers: dict[str, str] = {}
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+        self.get_calls: list[tuple[str, dict[str, str]]] = []
+
+    def post(self, url: str, *, data: dict[str, Any], timeout: int) -> FakeResponse:
+        """Return a successful Czech token response."""
+        self.post_calls.append((url, data))
+        assert timeout == 30
+        return FakeResponse(
+            {
+                "access_token": "access-token",
+                "InstanceId": 42,
+                "FirstName": "Test",
+                "Email": "test@example.com",
+                "Language": "cs-CZ",
+            }
+        )
+
+    def get(self, url: str, *, headers: dict[str, str], timeout: int) -> FakeResponse:
+        """Return meters or chart readings for the requested URL."""
+        self.get_calls.append((url, headers))
+        assert timeout == 30
+        if url == CZECH_METERS_URL:
+            return FakeResponse(
+                {
+                    "Meters": {
+                        "Value": [
+                            {
+                                "MeterType": "HCA",
+                                "Unit": "díl",
+                                "METER_ID": 101.0,
+                                "METER_NO": "H-1",
+                                "INST_NO": 1,
+                                "ROOM_DESCR": "Obývací pokoj",
+                                "Headline": "Topení",
+                                "METCAT_LABEL": "Rozdělovač topných nákladů",
+                                "Last_Meter_Reading": "120,5",
+                                "Last_Meter_Consumption": "8,5",
+                                "Reading_date": "2026-07-10",
+                            },
+                            {
+                                "MeterType": "HCA",
+                                "Unit": "díl",
+                                "METER_ID": 102,
+                                "METER_NO": "H-2",
+                                "INST_NO": 2,
+                                "ROOM_DESCR": "Ložnice",
+                                "Headline": "Topení",
+                                "Last_Meter_Reading": 80,
+                                "Last_Meter_Consumption": 4,
+                                "Reading_date": "2026-07-10",
+                            },
+                            {
+                                "MeterType": "HCA",
+                                "Unit": "díl",
+                                "METER_ID": 103,
+                                "METER_NO": "H-3",
+                                "INST_NO": 3,
+                                "ROOM_DESCR": "Pokoj",
+                                "Headline": "Topení",
+                                "Last_Meter_Reading": 60,
+                                "Last_Meter_Consumption": 3,
+                                "Reading_date": "2026-07-10",
+                            },
+                            {
+                                "MeterType": "HW",
+                                "Unit": "m3",
+                                "METER_ID": 201,
+                                "METER_NO": "TV-1",
+                                "INST_NO": 4,
+                                "ROOM_DESCR": "Koupelna",
+                                "Headline": "Teplá voda",
+                                "Last_Meter_Reading": "12,3",
+                                "Last_Meter_Consumption": "0,75",
+                                "Reading_date": "2026-07-10",
+                            },
+                            {
+                                "MeterType": "CW",
+                                "Unit": "m3",
+                                "METER_ID": 202,
+                                "METER_NO": "SV-1",
+                                "INST_NO": 5,
+                                "ROOM_DESCR": "Koupelna",
+                                "Headline": "Studená voda",
+                                "Last_Meter_Reading": 24,
+                                "Last_Meter_Consumption": 2,
+                                "Reading_date": "2026-07-10",
+                            },
+                        ]
+                    }
+                }
+            )
+        if url.endswith("/hca"):
+            if "/4/" in url:
+                return FakeResponse(
+                    {
+                        "readingsList": {
+                            "Value": {
+                                "Unit": "díl",
+                                "Readings": [
+                                    {
+                                        "Date": "2026-07-01T00:00:00",
+                                        "Value": "1,25",
+                                        "AkkumulativValue": "100,0",
+                                    },
+                                    {
+                                        "Date": "2026-07-02T00:00:00",
+                                        "Value": "2,75",
+                                        "AkkumulativValue": "102,75",
+                                    },
+                                ],
+                            }
+                        }
+                    }
+                )
+            return FakeResponse(
+                {
+                    "readingsList": {
+                        "Value": {
+                            "Unit": "díl",
+                            "Readings": [{"Date": "2026-07-01T00:00:00", "Value": "8,5"}],
+                        }
+                    }
+                }
+            )
+        if url.endswith("/hw"):
+            if "/4/" in url:
+                return FakeResponse(
+                    {
+                        "readingsList": {
+                            "Value": {
+                                "Unit": "m³",
+                                "Readings": [
+                                    {
+                                        "Date": "2026-07-01T00:00:00",
+                                        "Value": "0,1",
+                                        "AkkumulativValue": "10,1",
+                                    },
+                                    {
+                                        "Date": "2026-07-02T00:00:00",
+                                        "Value": "0,2",
+                                        "AkkumulativValue": "10,3",
+                                    },
+                                ],
+                            }
+                        }
+                    }
+                )
+            return FakeResponse(
+                {
+                    "readingsList": {
+                        "Value": {
+                            "Unit": "m3",
+                            "Readings": [{"Date": "2026-07-01T00:00:00", "Value": "0,75"}],
+                        }
+                    }
+                }
+            )
+        if url.endswith("/cw"):
+            if "/4/" in url:
+                return FakeResponse(
+                    {
+                        "readingsList": {
+                            "Value": {
+                                "Unit": "m³",
+                                "Readings": [
+                                    {
+                                        "Date": "2026-07-01T00:00:00",
+                                        "Value": 1,
+                                        "AkkumulativValue": 20,
+                                    },
+                                    {
+                                        "Date": "2026-07-02T00:00:00",
+                                        "Value": 2,
+                                        "AkkumulativValue": 22,
+                                    },
+                                ],
+                            }
+                        }
+                    }
+                )
+            return FakeResponse(
+                {
+                    "readingsList": {
+                        "Value": {
+                            "Unit": "m³",
+                            "Readings": [{"Date": "/Date(1782864000000)/", "Value": 2}],
+                        }
+                    }
+                }
+            )
+        raise AssertionError(f"Unexpected URL: {url}")
+
+
+def test_login_proofs_match_captured_web_client_request() -> None:
+    """The implementation must stay byte-compatible with the public WebGL client."""
+
+    value1, value2 = _login_proofs(
+        "codex-invalid-user",
+        "invalid-password",
+        datetime(2026, 7, 16, 12, 52, 16),
+    )
+
+    assert value1 == (
+        "_29_52_239_8_77_180_114_223_83_241_34_104_193_176_21_187"
+        "_62_46_46_224_141_159_219_13_137_15_254_249_205_176_109_42"
+        "_123_135_165_8_55_27_122_174_165_10_243_102_97_93_135_24"
+    )
+    assert value2 == (
+        "_117_59_26_69_252_242_214_228_128_238_132_124_149_96_74_154"
+        "_102_222_40_40_212_151_205_51_51_128_143_51_21_208_18_58"
+        "_205_162_56_12_7_238_110_252_71_130_245_72_5_101_22_81"
+    )
+
+
+def test_login_and_normalize_readings() -> None:
+    """Token, meters and chart data are translated to the existing consumption shape."""
+
+    session = FakeSession()
+    client = CzechPyEcotrendIsta("tenant-login", "secret", session=session)
+
+    client.login()
+    consumption_data = client.get_consumption_data()
+
+    assert session.post_calls[0][0] == CZECH_TOKEN_URL
+    token_form = session.post_calls[0][1]
+    assert set(token_form) == {"grant_type", "username", "password", "value1", "value2"}
+    assert token_form["username"] == "tenant-login"
+    assert client.access_token == "access-token"
+    assert client.get_uuids() == ["cz-42"]
+    assert all(headers == {"Authorization": "bearer access-token"} for _, headers in session.get_calls)
+    assert all(
+        url == CZECH_METERS_URL or url.startswith(f"{CZECH_READING_URL}/")
+        for url, _ in session.get_calls
+    )
+    assert all("/2/" in url for url, _ in session.get_calls if url != CZECH_METERS_URL)
+
+    readings = {reading["type"]: reading for reading in consumption_data["consumptions"][0]["readings"]}
+    assert readings["heating"]["value"] == "8.5"
+    assert readings["heating"]["unit"] == "díl"
+    assert readings["warmwater"]["value"] == "0.75"
+    assert readings["warmwater"]["unit"] == "m³"
+    assert readings["water"]["value"] == "2"
+    assert readings["water"]["unit"] == "m³"
+
+
+def test_home_assistant_data_exposes_five_meters_and_aggregate_periods() -> None:
+    """The Czech account exposes physical meters plus daily and monthly aggregate sensors."""
+
+    session = FakeSession()
+    client = CzechPyEcotrendIsta("tenant-login", "secret", session=session)
+
+    client.login()
+    home_data = client.get_home_assistant_data()
+
+    assert len(home_data["meters"]) == 5
+    assert [meter["id"] for meter in home_data["meters"]] == ["101", "102", "103", "201", "202"]
+    assert [meter["type"] for meter in home_data["meters"]] == [
+        "heating",
+        "heating",
+        "heating",
+        "warmwater",
+        "water",
+    ]
+    assert home_data["meters"][0]["room"] == "Obývací pokoj"
+    assert home_data["meters"][0]["value"] == "120.5"
+    assert home_data["meters"][3]["last_consumption"] == "0.75"
+
+    aggregates = home_data["aggregates"]
+    assert aggregates["heating"]["daily_value"] == "2.75"
+    assert aggregates["heating"]["monthly_value"] == "4"
+    assert aggregates["warmwater"]["monthly_value"] == "0.3"
+    assert aggregates["water"]["monthly_value"] == "3"
+    assert aggregates["water"]["daily"][-1] == {
+        "date": "2026-07-02",
+        "value": "2",
+        "cumulative_value": "22",
+    }
+
+    daily_urls = [
+        url
+        for url, _headers in session.get_calls
+        if url.startswith(f"{CZECH_READING_URL}/") and "/4/" in url
+    ]
+    assert len(daily_urls) == 3
+    assert sum(url.endswith("/hca") for url in daily_urls) == 1
+
+    monthly_data = client.get_consumption_data()
+    assert not any(
+        url.startswith(f"{CZECH_READING_URL}/") and "/2/" in url
+        for url, _headers in session.get_calls
+    )
+    monthly_readings = {
+        reading["type"]: reading
+        for reading in monthly_data["consumptions"][0]["readings"]
+    }
+    assert monthly_readings["heating"]["value"] == "4"
+    assert monthly_readings["warmwater"]["value"] == "0.3"
+    assert monthly_readings["water"]["value"] == "3"

--- a/tests/test_czech_client.py
+++ b/tests/test_czech_client.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 
 from custom_components.ecotrend_ista.czech_client import (
@@ -10,8 +11,12 @@ from custom_components.ecotrend_ista.czech_client import (
     CZECH_READING_URL,
     CZECH_TOKEN_URL,
     CzechPyEcotrendIsta,
+    _account_identifier,
+    _as_decimal,
+    _decimal_string,
     _login_proofs,
 )
+import pytest
 
 
 class FakeResponse:
@@ -66,7 +71,7 @@ class FakeSession:
                         "Value": [
                             {
                                 "MeterType": "HCA",
-                                "Unit": "díl",
+                                "Unit": "(jednotky)",
                                 "METER_ID": 101.0,
                                 "METER_NO": "H-1",
                                 "INST_NO": 1,
@@ -79,7 +84,7 @@ class FakeSession:
                             },
                             {
                                 "MeterType": "HCA",
-                                "Unit": "díl",
+                                "Unit": "(jednotky)",
                                 "METER_ID": 102,
                                 "METER_NO": "H-2",
                                 "INST_NO": 2,
@@ -91,7 +96,7 @@ class FakeSession:
                             },
                             {
                                 "MeterType": "HCA",
-                                "Unit": "díl",
+                                "Unit": "(jednotky)",
                                 "METER_ID": 103,
                                 "METER_NO": "H-3",
                                 "INST_NO": 3,
@@ -135,7 +140,7 @@ class FakeSession:
                     {
                         "readingsList": {
                             "Value": {
-                                "Unit": "díl",
+                                "Unit": "Dílků",
                                 "Readings": [
                                     {
                                         "Date": "2026-07-01T00:00:00",
@@ -156,7 +161,7 @@ class FakeSession:
                 {
                     "readingsList": {
                         "Value": {
-                            "Unit": "díl",
+                            "Unit": "Dílků",
                             "Readings": [{"Date": "2026-07-01T00:00:00", "Value": "8,5"}],
                         }
                     }
@@ -231,6 +236,65 @@ class FakeSession:
         raise AssertionError(f"Unexpected URL: {url}")
 
 
+def test_provider_numbers_are_bounded_before_fixed_point_formatting() -> None:
+    """Tiny exponent inputs must not expand into unbounded strings."""
+    assert _as_decimal("1234,567") == Decimal("1234.567")
+    assert _as_decimal("1e1000000") is None
+    assert _as_decimal("1e-1000000") is None
+    assert _as_decimal("NaN") is None
+    assert _as_decimal("Infinity") is None
+    assert _decimal_string(Decimal("1e1000000")) is None
+
+
+def test_account_identifier_separates_logins_on_the_same_provider_instance() -> None:
+    """Two accounts must not share entities or statistics solely due to InstanceId."""
+    first = _account_identifier("first@example.com", 42)
+    second = _account_identifier("second@example.com", 42)
+
+    assert first != second
+    assert first == _account_identifier(" FIRST@example.com ", 42)
+    assert "first@example.com" not in first
+
+
+def test_daily_history_is_limited_to_requested_dates_and_response_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider history outside the request window or size cap is ignored."""
+    today = date.today()
+    client = CzechPyEcotrendIsta("tenant-login", "secret", session=FakeSession())
+    client._meters = [
+        {
+            "MeterType": "CW",
+            "METER_ID": 1,
+            "Unit": "m3",
+            "Last_Meter_Reading": 10,
+            "Reading_date": today.isoformat(),
+        }
+    ]
+    readings = [
+        {"Date": (today - timedelta(days=500)).isoformat(), "Value": 100},
+        {"Date": (today + timedelta(days=1)).isoformat(), "Value": 100},
+        *({"Date": today.isoformat(), "Value": 1} for _ in range(4_998)),
+        {"Date": today.isoformat(), "Value": 100},
+    ]
+
+    monkeypatch.setattr(
+        client,
+        "_get_readings",
+        lambda *_args, **_kwargs: {"Unit": "m3", "Readings": readings},
+    )
+
+    aggregate = client.get_home_assistant_data()["aggregates"]["water"]
+
+    assert aggregate["daily"] == [
+        {
+            "date": today.isoformat(),
+            "value": "4998",
+            "cumulative_value": None,
+        }
+    ]
+
+
 def test_login_proofs_match_captured_web_client_request() -> None:
     """The implementation must stay byte-compatible with the public WebGL client."""
 
@@ -266,17 +330,14 @@ def test_login_and_normalize_readings() -> None:
     assert set(token_form) == {"grant_type", "username", "password", "value1", "value2"}
     assert token_form["username"] == "tenant-login"
     assert client.access_token == "access-token"
-    assert client.get_uuids() == ["cz-42"]
+    assert client.get_uuids() == [_account_identifier("tenant-login", 42)]
     assert all(headers == {"Authorization": "bearer access-token"} for _, headers in session.get_calls)
-    assert all(
-        url == CZECH_METERS_URL or url.startswith(f"{CZECH_READING_URL}/")
-        for url, _ in session.get_calls
-    )
+    assert all(url == CZECH_METERS_URL or url.startswith(f"{CZECH_READING_URL}/") for url, _ in session.get_calls)
     assert all("/2/" in url for url, _ in session.get_calls if url != CZECH_METERS_URL)
 
     readings = {reading["type"]: reading for reading in consumption_data["consumptions"][0]["readings"]}
     assert readings["heating"]["value"] == "8.5"
-    assert readings["heating"]["unit"] == "díl"
+    assert readings["heating"]["unit"] == "jednotek"
     assert readings["warmwater"]["value"] == "0.75"
     assert readings["warmwater"]["unit"] == "m³"
     assert readings["water"]["value"] == "2"
@@ -303,6 +364,7 @@ def test_home_assistant_data_exposes_five_meters_and_aggregate_periods() -> None
     ]
     assert home_data["meters"][0]["room"] == "Obývací pokoj"
     assert home_data["meters"][0]["value"] == "120.5"
+    assert home_data["meters"][0]["unit"] == "jednotek"
     assert home_data["meters"][3]["last_consumption"] == "0.75"
 
     aggregates = home_data["aggregates"]
@@ -316,23 +378,13 @@ def test_home_assistant_data_exposes_five_meters_and_aggregate_periods() -> None
         "cumulative_value": "22",
     }
 
-    daily_urls = [
-        url
-        for url, _headers in session.get_calls
-        if url.startswith(f"{CZECH_READING_URL}/") and "/4/" in url
-    ]
+    daily_urls = [url for url, _headers in session.get_calls if url.startswith(f"{CZECH_READING_URL}/") and "/4/" in url]
     assert len(daily_urls) == 3
     assert sum(url.endswith("/hca") for url in daily_urls) == 1
 
     monthly_data = client.get_consumption_data()
-    assert not any(
-        url.startswith(f"{CZECH_READING_URL}/") and "/2/" in url
-        for url, _headers in session.get_calls
-    )
-    monthly_readings = {
-        reading["type"]: reading
-        for reading in monthly_data["consumptions"][0]["readings"]
-    }
+    assert not any(url.startswith(f"{CZECH_READING_URL}/") and "/2/" in url for url, _headers in session.get_calls)
+    monthly_readings = {reading["type"]: reading for reading in monthly_data["consumptions"][0]["readings"]}
     assert monthly_readings["heating"]["value"] == "4"
     assert monthly_readings["warmwater"]["value"] == "0.3"
     assert monthly_readings["water"]["value"] == "3"

--- a/tests/test_czech_client.py
+++ b/tests/test_czech_client.py
@@ -325,6 +325,7 @@ def test_login_and_normalize_readings() -> None:
     client.login()
     consumption_data = client.get_consumption_data()
 
+    assert CZECH_TOKEN_URL.startswith("https://")
     assert session.post_calls[0][0] == CZECH_TOKEN_URL
     token_form = session.post_calls[0][1]
     assert set(token_form) == {"grant_type", "username", "password", "value1", "value2"}

--- a/tests/test_czech_sensor.py
+++ b/tests/test_czech_sensor.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import date
 from typing import Any
 
 from custom_components.ecotrend_ista.czech_sensor import (
     CzechAggregateSensor,
+    CzechDataFreshnessSensor,
     CzechPhysicalMeterSensor,
     create_czech_sensor_entities,
 )
@@ -51,7 +52,7 @@ def _payload() -> dict[str, Any]:
             "room": "Obývací pokoj",
             "label": "Topení",
             "category": "Rozdělovač",
-            "unit": "díl",
+            "unit": "(jednotky)",
             "value": "120.5",
             "last_consumption": "8.5",
             "reading_date": "2026-07-10T00:00:00",
@@ -60,14 +61,14 @@ def _payload() -> dict[str, Any]:
             "id": "102",
             "type": "heating",
             "room": "Ložnice",
-            "unit": "díl",
+            "unit": "(jednotky)",
             "value": "80",
         },
         {
             "id": "103",
             "type": "heating",
             "room": "Pokoj",
-            "unit": "díl",
+            "unit": "(jednotky)",
             "value": "60",
         },
         {
@@ -87,7 +88,7 @@ def _payload() -> dict[str, Any]:
     ]
     aggregates = {
         "heating": {
-            "unit": "díl",
+            "unit": "Dílků",
             "daily": [{"date": "2026-07-15", "value": "3.5"}],
             "monthly": [{"year": 2026, "month": 7, "value": "20"}],
             "daily_value": "3.5",
@@ -128,40 +129,38 @@ def test_create_czech_entities_exposes_five_meters_and_six_aggregates() -> None:
     physical = [entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor)]
     aggregates = [entity for entity in entities if isinstance(entity, CzechAggregateSensor)]
 
-    assert len(entities) == 11
+    freshness = [entity for entity in entities if isinstance(entity, CzechDataFreshnessSensor)]
+
+    assert len(entities) == 12
     assert len(physical) == 5
     assert len(aggregates) == 6
-    assert len({entity._attr_unique_id for entity in entities}) == 11
-    assert all(
-        entity._attr_device_info["identifiers"] == {("ecotrend_ista", "cz-42")}
-        for entity in entities
-    )
+    assert len(freshness) == 1
+    assert len({entity._attr_unique_id for entity in entities}) == 12
+    assert all(entity._attr_device_info["identifiers"] == {("ecotrend_ista", "cz-42")} for entity in entities)
 
 
 def test_physical_meter_values_and_metadata_follow_coordinator_updates() -> None:
     """Physical sensors should update dynamically without recreating entities."""
     coordinator = DummyCoordinator(_payload())
     entities = create_czech_sensor_entities(coordinator)
-    heating = next(
-        entity
-        for entity in entities
-        if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "101"
-    )
+    heating = next(entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "101")
     warmwater = next(
-        entity
-        for entity in entities
-        if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "201"
+        entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "201"
     )
 
     assert heating.native_value == 120.5
-    assert heating.native_unit_of_measurement == "díl"
+    assert heating._attr_translation_key == "czech_heating_meter"
+    assert heating._attr_translation_placeholders == {"detail": "Obývací pokoj (H-1)"}
+    assert heating.native_unit_of_measurement is None
     assert heating._attr_state_class is SensorStateClass.TOTAL_INCREASING
     assert heating.extra_state_attributes["room"] == "Obývací pokoj"
     assert "daily" not in heating.extra_state_attributes
     assert warmwater.native_unit_of_measurement == "m³"
     assert warmwater._attr_device_class is SensorDeviceClass.WATER
 
-    coordinator.czech_data["meters"][0]["value"] = "130.25"
+    coordinator.czech_data["meters"] = [
+        {**meter, "value": "130.25"} if meter["id"] == "101" else meter for meter in coordinator.czech_data["meters"]
+    ]
     assert heating.native_value == 130.25
 
 
@@ -172,32 +171,100 @@ def test_aggregate_sensors_report_period_values_without_history_attributes() -> 
     daily = next(
         entity
         for entity in entities
-        if isinstance(entity, CzechAggregateSensor)
-        and entity._consumption_type == "heating"
-        and entity._period == "daily"
+        if isinstance(entity, CzechAggregateSensor) and entity._consumption_type == "heating" and entity._period == "daily"
     )
     monthly = next(
         entity
         for entity in entities
-        if isinstance(entity, CzechAggregateSensor)
-        and entity._consumption_type == "water"
-        and entity._period == "monthly"
+        if isinstance(entity, CzechAggregateSensor) and entity._consumption_type == "water" and entity._period == "monthly"
     )
 
     assert daily.native_value == 3.5
-    assert daily._attr_state_class is SensorStateClass.TOTAL
-    assert daily.last_reset == datetime(2026, 7, 15, tzinfo=UTC)
-    assert daily.extra_state_attributes == {
-        "consumption_type": "heating",
-        "period": "daily",
-        "latest_period": "2026-07-15",
-        "external_statistic_id": "ecotrend_ista:cz_42_heating_daily",
-    }
+    assert daily._attr_translation_key == "czech_heating_daily"
+    assert daily.native_unit_of_measurement is None
+    assert not hasattr(daily, "_attr_state_class")
+    assert not hasattr(daily, "last_reset")
+    daily_attributes = daily.extra_state_attributes
+    assert daily_attributes["consumption_type"] == "heating"
+    assert daily_attributes["period"] == "daily"
+    assert daily_attributes["latest_period"] == "2026-07-15"
+    assert daily_attributes["data_through"] == "2026-07-15"
+    assert isinstance(daily_attributes["delay_days"], int)
+    assert daily_attributes["external_statistic_id"] == "ecotrend_ista:cz_42_heating_daily"
     assert monthly.native_value == 2.4
+    assert monthly._attr_translation_key == "czech_cold_water_monthly"
     assert monthly.native_unit_of_measurement == "m³"
-    assert monthly.last_reset == datetime(2026, 7, 1, tzinfo=UTC)
     assert "daily" not in monthly.extra_state_attributes
     assert "monthly" not in monthly.extra_state_attributes
 
     coordinator.czech_data["aggregates"]["water"]["monthly_value"] = "3.1"
     assert monthly.native_value == 3.1
+
+
+def test_data_freshness_uses_oldest_latest_date_across_consumption_types() -> None:
+    """The displayed cutoff date must be valid for every available type."""
+    payload = _payload()
+    payload["aggregates"]["heating"]["daily_date"] = "2026-07-14"
+    coordinator = DummyCoordinator(payload)
+    freshness = next(
+        entity for entity in create_czech_sensor_entities(coordinator) if isinstance(entity, CzechDataFreshnessSensor)
+    )
+
+    assert freshness.native_value == date(2026, 7, 14)
+    assert freshness._attr_device_class is SensorDeviceClass.DATE
+    assert freshness._attr_translation_key == "czech_data_through"
+    assert freshness.extra_state_attributes["heating_data_through"] == "2026-07-14"
+    assert freshness.extra_state_attributes["hot_water_data_through"] == "2026-07-15"
+    assert freshness.extra_state_attributes["cold_water_data_through"] == "2026-07-15"
+    assert isinstance(freshness.extra_state_attributes["delay_days"], int)
+
+
+def test_data_freshness_is_unknown_when_an_expected_type_has_no_history() -> None:
+    """The shared cutoff must not hide a missing history for an installed type."""
+    payload = _payload()
+    del payload["aggregates"]["heating"]
+    coordinator = DummyCoordinator(payload)
+    freshness = next(
+        entity for entity in create_czech_sensor_entities(coordinator) if isinstance(entity, CzechDataFreshnessSensor)
+    )
+
+    assert freshness.native_value is None
+    assert "heating_data_through" not in freshness.extra_state_attributes
+
+
+def test_aggregate_entities_are_only_created_for_installed_consumption_types() -> None:
+    """Accounts without a medium should not receive permanently unknown entities."""
+    payload = _payload()
+    payload["meters"] = [meter for meter in payload["meters"] if meter["type"] == "water"]
+    payload["aggregates"] = {"water": payload["aggregates"]["water"]}
+
+    entities = create_czech_sensor_entities(DummyCoordinator(payload))
+    aggregates = [entity for entity in entities if isinstance(entity, CzechAggregateSensor)]
+
+    assert len(entities) == 4
+    assert {(entity._consumption_type, entity._period) for entity in aggregates} == {
+        ("water", "daily"),
+        ("water", "monthly"),
+    }
+
+
+def test_heating_energy_meter_keeps_its_native_unit() -> None:
+    """A non-allocation heating meter must not be relabeled as allocation units."""
+    payload = _payload()
+    for meter in payload["meters"]:
+        if meter["type"] == "heating":
+            meter["unit"] = "kWh"
+    payload["aggregates"]["heating"]["unit"] = "kWh"
+
+    entities = create_czech_sensor_entities(DummyCoordinator(payload))
+    meter = next(entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor))
+    daily = next(
+        entity
+        for entity in entities
+        if isinstance(entity, CzechAggregateSensor) and entity._consumption_type == "heating" and entity._period == "daily"
+    )
+
+    assert meter._attr_translation_key == "czech_heating_meter_native_unit"
+    assert meter.native_unit_of_measurement == "kWh"
+    assert daily._attr_translation_key == "czech_heating_daily_native_unit"
+    assert daily.native_unit_of_measurement == "kWh"

--- a/tests/test_czech_sensor.py
+++ b/tests/test_czech_sensor.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Any
+from typing import Any, cast
 
+from custom_components.ecotrend_ista.coordinator import IstaDataUpdateCoordinator
 from custom_components.ecotrend_ista.czech_sensor import (
     CzechAggregateSensor,
     CzechDataFreshnessSensor,
@@ -12,6 +13,7 @@ from custom_components.ecotrend_ista.czech_sensor import (
     create_czech_sensor_entities,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+import pytest
 
 
 class DummyController:
@@ -38,6 +40,11 @@ class DummyCoordinator:
         self.controller = DummyController()
         self.czech_data = payload
         self.data = payload
+
+
+def _coordinator(payload: dict[str, Any]) -> IstaDataUpdateCoordinator:
+    """Return the structurally compatible sensor coordinator test double."""
+    return cast(IstaDataUpdateCoordinator, DummyCoordinator(payload))
 
 
 def _payload() -> dict[str, Any]:
@@ -123,7 +130,7 @@ def _payload() -> dict[str, Any]:
 
 def test_create_czech_entities_exposes_five_meters_and_six_aggregates() -> None:
     """The Czech account should create the requested 11 stable entities."""
-    coordinator = DummyCoordinator(_payload())
+    coordinator = _coordinator(_payload())
 
     entities = create_czech_sensor_entities(coordinator)
     physical = [entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor)]
@@ -141,14 +148,14 @@ def test_create_czech_entities_exposes_five_meters_and_six_aggregates() -> None:
 
 def test_physical_meter_values_and_metadata_follow_coordinator_updates() -> None:
     """Physical sensors should update dynamically without recreating entities."""
-    coordinator = DummyCoordinator(_payload())
+    coordinator = _coordinator(_payload())
     entities = create_czech_sensor_entities(coordinator)
     heating = next(entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "101")
     warmwater = next(
         entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "201"
     )
 
-    assert heating.native_value == 120.5
+    assert heating.native_value == pytest.approx(120.5)
     assert heating._attr_translation_key == "czech_heating_meter"
     assert heating._attr_translation_placeholders == {"detail": "Obývací pokoj (H-1)"}
     assert heating.native_unit_of_measurement is None
@@ -161,12 +168,12 @@ def test_physical_meter_values_and_metadata_follow_coordinator_updates() -> None
     coordinator.czech_data["meters"] = [
         {**meter, "value": "130.25"} if meter["id"] == "101" else meter for meter in coordinator.czech_data["meters"]
     ]
-    assert heating.native_value == 130.25
+    assert heating.native_value == pytest.approx(130.25)
 
 
 def test_aggregate_sensors_report_period_values_without_history_attributes() -> None:
     """Daily and monthly sensors should expose only their latest interval."""
-    coordinator = DummyCoordinator(_payload())
+    coordinator = _coordinator(_payload())
     entities = create_czech_sensor_entities(coordinator)
     daily = next(
         entity
@@ -179,7 +186,7 @@ def test_aggregate_sensors_report_period_values_without_history_attributes() -> 
         if isinstance(entity, CzechAggregateSensor) and entity._consumption_type == "water" and entity._period == "monthly"
     )
 
-    assert daily.native_value == 3.5
+    assert daily.native_value == pytest.approx(3.5)
     assert daily._attr_translation_key == "czech_heating_daily"
     assert daily.native_unit_of_measurement is None
     assert not hasattr(daily, "_attr_state_class")
@@ -191,21 +198,21 @@ def test_aggregate_sensors_report_period_values_without_history_attributes() -> 
     assert daily_attributes["data_through"] == "2026-07-15"
     assert isinstance(daily_attributes["delay_days"], int)
     assert daily_attributes["external_statistic_id"] == "ecotrend_ista:cz_42_heating_daily"
-    assert monthly.native_value == 2.4
+    assert monthly.native_value == pytest.approx(2.4)
     assert monthly._attr_translation_key == "czech_cold_water_monthly"
     assert monthly.native_unit_of_measurement == "m³"
     assert "daily" not in monthly.extra_state_attributes
     assert "monthly" not in monthly.extra_state_attributes
 
     coordinator.czech_data["aggregates"]["water"]["monthly_value"] = "3.1"
-    assert monthly.native_value == 3.1
+    assert monthly.native_value == pytest.approx(3.1)
 
 
 def test_data_freshness_uses_oldest_latest_date_across_consumption_types() -> None:
     """The displayed cutoff date must be valid for every available type."""
     payload = _payload()
     payload["aggregates"]["heating"]["daily_date"] = "2026-07-14"
-    coordinator = DummyCoordinator(payload)
+    coordinator = _coordinator(payload)
     freshness = next(
         entity for entity in create_czech_sensor_entities(coordinator) if isinstance(entity, CzechDataFreshnessSensor)
     )
@@ -223,7 +230,7 @@ def test_data_freshness_is_unknown_when_an_expected_type_has_no_history() -> Non
     """The shared cutoff must not hide a missing history for an installed type."""
     payload = _payload()
     del payload["aggregates"]["heating"]
-    coordinator = DummyCoordinator(payload)
+    coordinator = _coordinator(payload)
     freshness = next(
         entity for entity in create_czech_sensor_entities(coordinator) if isinstance(entity, CzechDataFreshnessSensor)
     )
@@ -238,7 +245,7 @@ def test_aggregate_entities_are_only_created_for_installed_consumption_types() -
     payload["meters"] = [meter for meter in payload["meters"] if meter["type"] == "water"]
     payload["aggregates"] = {"water": payload["aggregates"]["water"]}
 
-    entities = create_czech_sensor_entities(DummyCoordinator(payload))
+    entities = create_czech_sensor_entities(_coordinator(payload))
     aggregates = [entity for entity in entities if isinstance(entity, CzechAggregateSensor)]
 
     assert len(entities) == 4
@@ -256,7 +263,7 @@ def test_heating_energy_meter_keeps_its_native_unit() -> None:
             meter["unit"] = "kWh"
     payload["aggregates"]["heating"]["unit"] = "kWh"
 
-    entities = create_czech_sensor_entities(DummyCoordinator(payload))
+    entities = create_czech_sensor_entities(_coordinator(payload))
     meter = next(entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor))
     daily = next(
         entity

--- a/tests/test_czech_sensor.py
+++ b/tests/test_czech_sensor.py
@@ -1,0 +1,203 @@
+"""Tests for Czech ista sensor entities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from custom_components.ecotrend_ista.czech_sensor import (
+    CzechAggregateSensor,
+    CzechPhysicalMeterSensor,
+    create_czech_sensor_entities,
+)
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+
+class DummyController:
+    """Expose stable account metadata for entity creation."""
+
+    def get_support_code(self) -> str:
+        """Return the account identifier."""
+        return "cz-42"
+
+    def get_uuids(self) -> list[str]:
+        """Return the account UUID fallback."""
+        return ["cz-42"]
+
+    def get_version(self) -> str:
+        """Return a display version."""
+        return "CZ Nordic 3.2.1"
+
+
+class DummyCoordinator:
+    """Hold the Czech payload used by coordinator entities."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        """Initialize coordinator state."""
+        self.controller = DummyController()
+        self.czech_data = payload
+        self.data = payload
+
+
+def _payload() -> dict[str, Any]:
+    """Return five physical meters and all three aggregate types."""
+    meters = [
+        {
+            "id": "101",
+            "type": "heating",
+            "meter_type": "hca",
+            "meter_number": "H-1",
+            "installation_number": "1",
+            "room": "Obývací pokoj",
+            "label": "Topení",
+            "category": "Rozdělovač",
+            "unit": "díl",
+            "value": "120.5",
+            "last_consumption": "8.5",
+            "reading_date": "2026-07-10T00:00:00",
+        },
+        {
+            "id": "102",
+            "type": "heating",
+            "room": "Ložnice",
+            "unit": "díl",
+            "value": "80",
+        },
+        {
+            "id": "103",
+            "type": "heating",
+            "room": "Pokoj",
+            "unit": "díl",
+            "value": "60",
+        },
+        {
+            "id": "201",
+            "type": "warmwater",
+            "room": "Koupelna",
+            "unit": "m3",
+            "value": "12.3",
+        },
+        {
+            "id": "202",
+            "type": "water",
+            "room": "Koupelna",
+            "unit": "m³",
+            "value": "24",
+        },
+    ]
+    aggregates = {
+        "heating": {
+            "unit": "díl",
+            "daily": [{"date": "2026-07-15", "value": "3.5"}],
+            "monthly": [{"year": 2026, "month": 7, "value": "20"}],
+            "daily_value": "3.5",
+            "daily_date": "2026-07-15",
+            "monthly_value": "20",
+            "monthly_year": 2026,
+            "monthly_month": 7,
+        },
+        "warmwater": {
+            "unit": "m³",
+            "daily": [{"date": "2026-07-15", "value": "0.2"}],
+            "monthly": [{"year": 2026, "month": 7, "value": "1.2"}],
+            "daily_value": "0.2",
+            "daily_date": "2026-07-15",
+            "monthly_value": "1.2",
+            "monthly_year": 2026,
+            "monthly_month": 7,
+        },
+        "water": {
+            "unit": "m³",
+            "daily": [{"date": "2026-07-15", "value": "0.4"}],
+            "monthly": [{"year": 2026, "month": 7, "value": "2.4"}],
+            "daily_value": "0.4",
+            "daily_date": "2026-07-15",
+            "monthly_value": "2.4",
+            "monthly_year": 2026,
+            "monthly_month": 7,
+        },
+    }
+    return {"meters": meters, "aggregates": aggregates}
+
+
+def test_create_czech_entities_exposes_five_meters_and_six_aggregates() -> None:
+    """The Czech account should create the requested 11 stable entities."""
+    coordinator = DummyCoordinator(_payload())
+
+    entities = create_czech_sensor_entities(coordinator)
+    physical = [entity for entity in entities if isinstance(entity, CzechPhysicalMeterSensor)]
+    aggregates = [entity for entity in entities if isinstance(entity, CzechAggregateSensor)]
+
+    assert len(entities) == 11
+    assert len(physical) == 5
+    assert len(aggregates) == 6
+    assert len({entity._attr_unique_id for entity in entities}) == 11
+    assert all(
+        entity._attr_device_info["identifiers"] == {("ecotrend_ista", "cz-42")}
+        for entity in entities
+    )
+
+
+def test_physical_meter_values_and_metadata_follow_coordinator_updates() -> None:
+    """Physical sensors should update dynamically without recreating entities."""
+    coordinator = DummyCoordinator(_payload())
+    entities = create_czech_sensor_entities(coordinator)
+    heating = next(
+        entity
+        for entity in entities
+        if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "101"
+    )
+    warmwater = next(
+        entity
+        for entity in entities
+        if isinstance(entity, CzechPhysicalMeterSensor) and entity._meter_id == "201"
+    )
+
+    assert heating.native_value == 120.5
+    assert heating.native_unit_of_measurement == "díl"
+    assert heating._attr_state_class is SensorStateClass.TOTAL_INCREASING
+    assert heating.extra_state_attributes["room"] == "Obývací pokoj"
+    assert "daily" not in heating.extra_state_attributes
+    assert warmwater.native_unit_of_measurement == "m³"
+    assert warmwater._attr_device_class is SensorDeviceClass.WATER
+
+    coordinator.czech_data["meters"][0]["value"] = "130.25"
+    assert heating.native_value == 130.25
+
+
+def test_aggregate_sensors_report_period_values_without_history_attributes() -> None:
+    """Daily and monthly sensors should expose only their latest interval."""
+    coordinator = DummyCoordinator(_payload())
+    entities = create_czech_sensor_entities(coordinator)
+    daily = next(
+        entity
+        for entity in entities
+        if isinstance(entity, CzechAggregateSensor)
+        and entity._consumption_type == "heating"
+        and entity._period == "daily"
+    )
+    monthly = next(
+        entity
+        for entity in entities
+        if isinstance(entity, CzechAggregateSensor)
+        and entity._consumption_type == "water"
+        and entity._period == "monthly"
+    )
+
+    assert daily.native_value == 3.5
+    assert daily._attr_state_class is SensorStateClass.TOTAL
+    assert daily.last_reset == datetime(2026, 7, 15, tzinfo=UTC)
+    assert daily.extra_state_attributes == {
+        "consumption_type": "heating",
+        "period": "daily",
+        "latest_period": "2026-07-15",
+        "external_statistic_id": "ecotrend_ista:cz_42_heating_daily",
+    }
+    assert monthly.native_value == 2.4
+    assert monthly.native_unit_of_measurement == "m³"
+    assert monthly.last_reset == datetime(2026, 7, 1, tzinfo=UTC)
+    assert "daily" not in monthly.extra_state_attributes
+    assert "monthly" not in monthly.extra_state_attributes
+
+    coordinator.czech_data["aggregates"]["water"]["monthly_value"] = "3.1"
+    assert monthly.native_value == 3.1

--- a/tests/test_czech_statistics.py
+++ b/tests/test_czech_statistics.py
@@ -61,12 +61,30 @@ def test_build_statistics_uses_complete_history_for_stable_running_sum() -> None
         date(2025, 1, 2),
     )
 
-    assert [item["state"] for item in statistics] == [4.0, 7.0]
+    assert [item["state"] for item in statistics] == [2.5, 3.0]
     assert [item["sum"] for item in statistics] == [4.0, 7.0]
     assert [item["start"] for item in statistics] == [
         datetime(2025, 1, 2, 23, tzinfo=UTC),
         datetime(2025, 1, 3, 23, tzinfo=UTC),
     ]
+
+
+def test_statistics_reject_values_that_cannot_be_stored_safely() -> None:
+    """Exponent expansion and non-finite recorder floats are rejected."""
+    assert czech_statistics._decimal_string("1e1000000") is None
+    assert czech_statistics._decimal_string("1e400") is None
+    assert czech_statistics._decimal_string("NaN") is None
+
+    statistics = czech_statistics._build_statistics(
+        {
+            "2025-01-01": "1e400",
+            "2025-01-02": "2",
+        },
+        date(2025, 1, 1),
+    )
+
+    assert [item["state"] for item in statistics] == [2.0]
+    assert [item["sum"] for item in statistics] == [2.0]
 
 
 def test_statistic_metadata_has_stable_id_and_volume_unit_class() -> None:
@@ -76,12 +94,14 @@ def test_statistic_metadata_has_stable_id_and_volume_unit_class() -> None:
     assert metadata == {
         "mean_type": czech_statistics.StatisticMeanType.NONE,
         "has_sum": True,
-        "name": "ista EcoTrend Teplá voda spotřeba",
+        "name": "ista EcoTrend Hot water consumption",
         "source": DOMAIN,
         "statistic_id": f"{DOMAIN}:cesky_ucet_42_warmwater_daily",
         "unit_class": "volume",
         "unit_of_measurement": "m³",
     }
+    assert czech_statistics._metadata("account", "warmwater", "m³", "cs")["name"] == ("ista EcoTrend Spotřeba teplé vody")
+    assert czech_statistics._metadata("account", "heating", "jednotek", "cs")["name"] == ("ista EcoTrend Spotřeba vytápění")
     assert czech_statistics._metadata("account", "heating", "Dílků")["unit_class"] is None
 
 

--- a/tests/test_czech_statistics.py
+++ b/tests/test_czech_statistics.py
@@ -1,0 +1,184 @@
+"""Tests for Czech ista recorder statistics."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta, timezone
+from typing import Any
+
+from custom_components.ecotrend_ista import czech_statistics
+from custom_components.ecotrend_ista.const import DOMAIN
+
+
+def test_merge_daily_history_retains_older_values_and_tracks_correction() -> None:
+    """Corrections should only replace matching days and retain all other history."""
+    stored = {
+        "types": {
+            "heating": {
+                "unit": "Dílků",
+                "daily": {
+                    "2025-01-01": "1",
+                    "2025-01-02": "2",
+                    "2025-01-03": "3",
+                },
+            },
+            "water": {
+                "unit": "m³",
+                "daily": {"2024-12-31": "0.5"},
+            },
+        }
+    }
+    aggregates = {
+        "heating": {
+            "unit": "Dílků",
+            "daily": [
+                {"date": "2025-01-02", "value": "2.5"},
+                {"date": "2025-01-04", "value": "4"},
+            ],
+        }
+    }
+
+    merged, earliest_changed = czech_statistics._merge_daily_history(stored, aggregates)
+
+    assert merged["types"]["heating"]["daily"] == {
+        "2025-01-01": "1",
+        "2025-01-02": "2.5",
+        "2025-01-03": "3",
+        "2025-01-04": "4",
+    }
+    assert merged["types"]["water"] == stored["types"]["water"]
+    assert earliest_changed == {"heating": date(2025, 1, 2)}
+
+
+def test_build_statistics_uses_complete_history_for_stable_running_sum() -> None:
+    """A partial reimport should still include values preceding the changed day."""
+    statistics = czech_statistics._build_statistics(
+        {
+            "2025-01-01": "1.5",
+            "2025-01-02": "2.5",
+            "2025-01-03": "3",
+        },
+        date(2025, 1, 2),
+    )
+
+    assert [item["state"] for item in statistics] == [4.0, 7.0]
+    assert [item["sum"] for item in statistics] == [4.0, 7.0]
+    assert [item["start"] for item in statistics] == [
+        datetime(2025, 1, 2, 23, tzinfo=UTC),
+        datetime(2025, 1, 3, 23, tzinfo=UTC),
+    ]
+
+
+def test_statistic_metadata_has_stable_id_and_volume_unit_class() -> None:
+    """Recorder metadata should use a valid external ID and an explicit unit class."""
+    metadata = czech_statistics._metadata("Český účet / 42", "warmwater", "m³")
+
+    assert metadata == {
+        "mean_type": czech_statistics.StatisticMeanType.NONE,
+        "has_sum": True,
+        "name": "ista EcoTrend Teplá voda spotřeba",
+        "source": DOMAIN,
+        "statistic_id": f"{DOMAIN}:cesky_ucet_42_warmwater_daily",
+        "unit_class": "volume",
+        "unit_of_measurement": "m³",
+    }
+    assert czech_statistics._metadata("account", "heating", "Dílků")["unit_class"] is None
+
+
+def test_statistics_timestamp_stays_in_the_local_calendar_day(monkeypatch) -> None:
+    """A daily interval should remain in its consumed local calendar day."""
+    monkeypatch.setattr(
+        czech_statistics.dt_util,
+        "DEFAULT_TIME_ZONE",
+        timezone(timedelta(hours=2)),
+    )
+
+    timestamp = czech_statistics._statistics_timestamp(date(2025, 3, 30))
+
+    assert timestamp == datetime(2025, 3, 30, 21, tzinfo=UTC)
+    assert timestamp.minute == timestamp.second == timestamp.microsecond == 0
+
+
+def test_async_sync_reimports_correction_and_future_sums(monkeypatch) -> None:
+    """A correction should upsert its timestamp and every affected later cumulative sum."""
+
+    class FakeConfig:
+        components = {"recorder"}
+
+    class FakeHass:
+        config = FakeConfig()
+
+    class FakeStore:
+        loaded = {
+            "types": {
+                "water": {
+                    "unit": "m³",
+                    "daily": {
+                        "2025-01-01": "1",
+                        "2025-01-02": "2",
+                        "2025-01-03": "3",
+                    },
+                }
+            }
+        }
+        saved: dict[str, Any] | None = None
+        key: str | None = None
+
+        def __init__(self, _hass: Any, _version: int, key: str) -> None:
+            type(self).key = key
+
+        async def async_load(self) -> dict[str, Any]:
+            return self.loaded
+
+        async def async_save(self, data: dict[str, Any]) -> None:
+            type(self).saved = data
+
+    imports: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+
+    def capture_import(_hass: Any, metadata: dict[str, Any], statistics: list[dict[str, Any]]) -> None:
+        imports.append((metadata, statistics))
+
+    monkeypatch.setattr(czech_statistics, "Store", FakeStore)
+    monkeypatch.setattr(czech_statistics, "async_add_external_statistics", capture_import)
+
+    asyncio.run(
+        czech_statistics.async_sync_czech_statistics(
+            FakeHass(),
+            "Support CZ",
+            {
+                "water": {
+                    "unit": "m³",
+                    "daily": [{"date": "2025-01-02", "value": "5"}],
+                }
+            },
+        )
+    )
+
+    assert FakeStore.key == f"{DOMAIN}.czech_statistics_support_cz"
+    assert FakeStore.saved["types"]["water"]["daily"]["2025-01-02"] == "5"
+    assert len(imports) == 1
+    metadata, statistics = imports[0]
+    assert metadata["statistic_id"] == f"{DOMAIN}:support_cz_water_daily"
+    assert [item["start"] for item in statistics] == [
+        datetime(2025, 1, 2, 23, tzinfo=UTC),
+        datetime(2025, 1, 3, 23, tzinfo=UTC),
+    ]
+    assert [item["sum"] for item in statistics] == [6.0, 9.0]
+
+
+def test_async_sync_skips_when_recorder_is_not_loaded(monkeypatch) -> None:
+    """Statistics synchronization should be harmless without recorder."""
+
+    class FakeConfig:
+        components: set[str] = set()
+
+    class FakeHass:
+        config = FakeConfig()
+
+    class UnexpectedStore:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("Store must not be opened without recorder")
+
+    monkeypatch.setattr(czech_statistics, "Store", UnexpectedStore)
+
+    asyncio.run(czech_statistics.async_sync_czech_statistics(FakeHass(), "account", {}))

--- a/tests/test_czech_statistics.py
+++ b/tests/test_czech_statistics.py
@@ -147,10 +147,12 @@ def test_async_sync_reimports_correction_and_future_sums(monkeypatch) -> None:
         def __init__(self, _hass: Any, _version: int, key: str) -> None:
             type(self).key = key
 
-        async def async_load(self) -> dict[str, Any]:
+        async def async_load(self) -> dict[str, Any]:  # NOSONAR - Fake mirrors Home Assistant's async Store API.
             return self.loaded
 
-        async def async_save(self, data: dict[str, Any]) -> None:
+        async def async_save(  # NOSONAR - Fake mirrors Home Assistant's async Store API.
+            self, data: dict[str, Any]
+        ) -> None:
             type(self).saved = data
 
     imports: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,53 @@
+"""Tests for privacy-safe integration diagnostics."""
+
+from __future__ import annotations
+
+from custom_components.ecotrend_ista.diagnostics import _czech_diagnostics
+
+
+def test_czech_diagnostics_omit_meter_identifiers_rooms_values_and_history() -> None:
+    """Czech diagnostics must expose structure without household consumption data."""
+    diagnostics = _czech_diagnostics(
+        {
+            "meters": [
+                {
+                    "id": "secret-meter-id",
+                    "type": "heating",
+                    "meter_number": "123456",
+                    "installation_number": "987654",
+                    "room": "Bedroom",
+                    "value": "428",
+                }
+            ],
+            "aggregates": {
+                "heating": {
+                    "unit": "jednotek",
+                    "daily": [{"date": "2026-07-10", "value": "1"}],
+                    "monthly": [{"year": 2026, "month": 7, "value": "20"}],
+                    "daily_value": "1",
+                    "monthly_value": "20",
+                }
+            },
+        }
+    )
+
+    assert diagnostics == {
+        "meter_count": 1,
+        "meter_types": ["heating"],
+        "aggregates": {
+            "heating": {
+                "unit": "jednotek",
+                "daily_reading_count": 1,
+                "monthly_reading_count": 1,
+                "has_latest_daily_value": True,
+                "has_latest_monthly_value": True,
+            }
+        },
+    }
+    serialized = repr(diagnostics)
+    assert "secret-meter-id" not in serialized
+    assert "123456" not in serialized
+    assert "987654" not in serialized
+    assert "Bedroom" not in serialized
+    assert "2026-07-10" not in serialized
+    assert "428" not in serialized

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,67 @@
+"""Tests for custom integration translations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+INTEGRATION = Path(__file__).parents[1] / "custom_components" / "ecotrend_ista"
+TRANSLATIONS = INTEGRATION / "translations"
+
+
+def _translation(language: str) -> dict[str, Any]:
+    """Load one integration translation file."""
+    with (TRANSLATIONS / f"{language}.json").open(encoding="utf-8") as translation_file:
+        return json.load(translation_file)
+
+
+def _key_paths(value: dict[str, Any], prefix: str = "") -> set[str]:
+    """Return every nested translation key path."""
+    paths: set[str] = set()
+    for key, nested_value in value.items():
+        path = f"{prefix}.{key}" if prefix else key
+        paths.add(path)
+        if isinstance(nested_value, dict):
+            paths.update(_key_paths(nested_value, path))
+    return paths
+
+
+def test_english_and_czech_expose_the_same_czech_sensor_translation_keys() -> None:
+    """Every Czech sensor name must be available in both supported languages."""
+    english_translation = _translation("en")
+    czech_translation = _translation("cs")
+    assert _key_paths(english_translation) == _key_paths(czech_translation)
+
+    english = english_translation["entity"]["sensor"]
+    czech = czech_translation["entity"]["sensor"]
+
+    assert set(english) == set(czech)
+    assert len(english) == 13
+    assert english["czech_heating_meter"]["name"] == "Heating meter reading – {detail}"
+    assert czech["czech_heating_meter"]["name"] == "Stav měřidla topení – {detail}"
+    assert english["czech_cold_water_daily"]["name"] == "Cold water – latest day"
+    assert czech["czech_cold_water_daily"]["name"] == "Studená voda – poslední den"
+    assert czech["czech_data_through"]["name"] == "Data dostupná do"
+    assert english["czech_heating_meter"]["unit_of_measurement"] == "units"
+    assert czech["czech_heating_meter"]["unit_of_measurement"] == "jednotek"
+
+
+def test_login_identifier_labels_allow_email_and_username() -> None:
+    """The shared login field must describe both backend identifier formats."""
+    english = _translation("en")["config"]["step"]["german"]["data"]
+    czech = _translation("cs")["config"]["step"]["german"]["data"]
+
+    assert english["email"] == "Email address or username"
+    assert czech["email"] == "E-mail nebo uživatelské jméno"
+
+
+def test_setup_field_labels_match_base_strings_in_both_languages() -> None:
+    """Every setup field must have a base, English and Czech label."""
+    with (INTEGRATION / "strings.json").open(encoding="utf-8") as strings_file:
+        base = json.load(strings_file)["config"]["step"]["german"]["data"]
+
+    english = _translation("en")["config"]["step"]["german"]["data"]
+    czech = _translation("cs")["config"]["step"]["german"]["data"]
+
+    assert set(base) == set(english) == set(czech)


### PR DESCRIPTION
## Summary

- add support for Czech accounts from `ecotrend.ista.cz`
- expose cumulative physical meter readings, latest available daily and monthly consumption, and a data-availability date sensor
- backfill delayed Czech daily readings into Home Assistant external statistics using their actual measurement dates
- add privacy-safe diagnostics, English and Czech localization, Czech setup documentation, and regression tests

## Compatibility

Existing German portal accounts continue to use the original `PyEcotrendIsta`, `CustomRaw`, and sensor creation path. Czech-specific API handling is activated only for entries configured with `cz_url`. A regression test verifies that German updates keep using the legacy consumption path.

## Motivation and implementation

The Czech customer portal uses a different backend and response format from the German portal. The Czech adapter normalizes account metadata and consumption types while preserving physical meter identifiers, cumulative readings, units, and the dates attached to delayed daily data.

Czech portal support is an unofficial community implementation and is not affiliated with or endorsed by ista. The backend may change or restrict access without notice. The default 24-hour update interval is recommended.

## Validation

- 38 pytest tests passed
- Ruff 0.13.3 check and format check passed on all changed Python files
- codespell 2.4.1 passed
- integration, manifest, strings, and translation JSON files parsed successfully
- Python compilation check passed
- hassfest and HACS validation passed
- `git diff --check` passed
- live synchronization verified with a Czech account, including delayed measurement dates
