### PR TITLE
Use workflow token for GitHub labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5.3.0
         with:
-          github-token: ${{ secrets.TOKEN }}
+          # Use the workflow token so label synchronization also works for pull
+          # requests where the repository-specific TOKEN secret is unavailable.
+          github-token: ${{ github.token }}
           yaml-file: .github/labels.yml
           skip-delete: true


### PR DESCRIPTION
### Motivation
- Ensure label synchronization runs on pull requests by using the built-in workflow token instead of a repository secret that may be unavailable in the PR context.

### Description
- Replace `github-token: ${{ secrets.TOKEN }}` with `github-token: ${{ github.token }}` in `.github/workflows/labeler.yml` and add a clarifying comment.

### Testing
- Ran `git diff --check` and `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/labeler.yml')"` to validate formatting and YAML parsing, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fe048c93c832595115e2f777f961c)